### PR TITLE
fix: add bottom padding to navigation

### DIFF
--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import {useColorScheme} from 'react-native';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import {MainTabParamList} from '@navigation/types';
 import HomeScreen from '@screens/HomeScreen';
@@ -13,6 +14,7 @@ const Tab = createBottomTabNavigator<MainTabParamList>();
 
 const MainNavigator = () => {
   const isDarkMode = useColorScheme() === 'dark';
+  const insets = useSafeAreaInsets();
 
   return (
     <Tab.Navigator
@@ -22,6 +24,8 @@ const MainNavigator = () => {
           backgroundColor: isDarkMode ? '#1A1A1A' : '#FFFFFF',
           borderTopColor: isDarkMode ? '#333333' : '#E5E7EB',
           paddingTop: 5,
+          paddingBottom: insets.bottom,
+          height: 60 + insets.bottom,
         },
         tabBarActiveTintColor: '#4F46E5',
         tabBarInactiveTintColor: isDarkMode ? '#888888' : '#6B7280',


### PR DESCRIPTION
안드로이드에서 네비게이션 하단이 잘리는 버그를 수정했습니다.

### 이전
<img width=300 src="https://github.com/user-attachments/assets/c043473d-ce36-479a-bc04-87e6cc532001" />

### 이후
<img width=300 src="https://github.com/user-attachments/assets/8e3835e5-12e5-484c-b4aa-5c5339840adf" />

