### PR TITLE
fix: fix whitebook link error on android

### DIFF
--- a/src/screens/WhitebookScreen.tsx
+++ b/src/screens/WhitebookScreen.tsx
@@ -68,13 +68,7 @@ const WhitebookScreen: React.FC<WhitebookScreenProps> = ({navigation}) => {
 
   const handleLinkPress = async (link: string) => {
     try {
-      const supported = await Linking.canOpenURL(link);
-
-      if (supported) {
-        await Linking.openURL(link);
-      } else {
-        Alert.alert('오류', '이 링크를 열 수 없습니다.', [{text: '확인'}]);
-      }
+      await Linking.openURL(link);
     } catch (error) {
       Alert.alert('오류', '링크를 여는 중 문제가 발생했습니다.', [
         {text: '확인'},


### PR DESCRIPTION
안드로이드에서 생활백서 링크가 열리지 않는 버그를 수정했습니다.

Linking.canOpenURL이 올바른 url도 false를 반환해서 그 부분을 제거했습니다.
이것을 없앰으로 인해 문제가 되는 부분이 있다면 알려주세요.