### PR TITLE
fix: realign description input in place reservation

### DIFF
--- a/src/screens/place-reservation/PlaceReservationApplyScreen.tsx
+++ b/src/screens/place-reservation/PlaceReservationApplyScreen.tsx
@@ -325,6 +325,7 @@ const PlaceReservationApplyScreen = ({
                 color: textColor,
                 backgroundColor: isDarkMode ? '#1A1A1A' : '#F9FAFB',
                 borderColor: borderColor,
+                textAlignVertical: 'top',
               },
             ]}
             value={desc}


### PR DESCRIPTION
장소 예약 페이지의 설명 입력 창의 텍스트 배열을 수정했습니다.

**이전**
<img width=300 src="https://github.com/user-attachments/assets/43a40928-397a-41de-a893-5f0912ca5b9e" />

**이후**
<img width=300 src="https://github.com/user-attachments/assets/6a4b9b27-6f12-464e-911b-7f933da67b95" />
