### PR TITLE
fix: fix paxi room list floating button

### DIFF
--- a/src/screens/paxi/PaxiRoomListScreen.tsx
+++ b/src/screens/paxi/PaxiRoomListScreen.tsx
@@ -220,16 +220,22 @@ const PaxiRoomListScreen = ({navigation}: PaxiRoomListScreenProps) => {
         removeClippedSubviews
       />
 
-      <TouchableOpacity
-        style={[
-          styles.floatingButton,
-          {
-            backgroundColor: isDarkMode ? '#444444' : '#222222',
-          },
-        ]}
-        onPress={() => navigation.navigate('CreatePaxiRoomScreen')}>
-        <Icon name="add" size={30} color={isDarkMode ? '#cccccc' : '#ffffff'} />
-      </TouchableOpacity>
+      <View style={styles.floatingButtonWrapper}>
+        <TouchableOpacity
+          style={[
+            styles.floatingButton,
+            {
+              backgroundColor: isDarkMode ? '#444444' : '#222222',
+            },
+          ]}
+          onPress={() => navigation.navigate('CreatePaxiRoomScreen')}>
+          <Icon
+            name="add"
+            size={30}
+            color={isDarkMode ? '#cccccc' : '#ffffff'}
+          />
+        </TouchableOpacity>
+      </View>
     </SafeAreaView>
   );
 };
@@ -317,12 +323,16 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: 12,
   },
-  floatingButton: {
+  floatingButtonWrapper: {
     position: 'absolute',
     bottom: 30,
     right: 30,
     width: 60,
     height: 60,
+  },
+  floatingButton: {
+    width: '100%',
+    height: '100%',
     borderRadius: 30,
     justifyContent: 'center',
     alignItems: 'center',


### PR DESCRIPTION
특정 안드로이드 기기에서 발생한다는 `paxi 방 생성 버튼 안보임 문제`를 해결했습니다. 아래의 링크를 참고하였습니다.
[Stack Overflow](https://stackoverflow.com/questions/51190180/react-native-position-absolute-not-working-in-android)
