### PR TITLE
fix: modify settlement info box

### DIFF
--- a/src/components/chat/SettlementInfoBox.tsx
+++ b/src/components/chat/SettlementInfoBox.tsx
@@ -10,16 +10,16 @@ import {
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import Clipboard from '@react-native-clipboard/clipboard';
 
-import {SettlementData} from '@interfaces/paxi';
+import {SettlementInfoData} from '@interfaces/paxi';
 import paxi_api from '@utils/paxi_api';
 import {textColor} from '@styles/default';
 
 interface SettlementInfoBoxProps {
   isPaid: boolean | undefined;
-  settlementData: SettlementData;
+  settlementData: SettlementInfoData;
 }
 
-async function completeSettlement(settlementData: SettlementData) {
+async function completeSettlement(settlementData: SettlementInfoData) {
   try {
     const res = await paxi_api.patch(`/room/${settlementData.roomUuid}/pay`, {
       isPaid: true,
@@ -139,11 +139,18 @@ const SettlementInfoBox = ({
               </Text>
               <Text
                 style={[styles.payAmountText, {color: textColor(isDarkMode)}]}>
-                {settlementData.payAmount?.toLocaleString()}원
+                {settlementData.payAmountPerPerson.toLocaleString()}원
               </Text>
             </View>
             <View style={styles.payerInfoContainer}>
               <View style={{marginTop: 10}}>
+                <Text
+                  style={[
+                    styles.infoText,
+                    {color: isDarkMode ? '#aaa' : '#4f4f4f'},
+                  ]}>
+                  총 금액: {settlementData.payAmount.toLocaleString()}원
+                </Text>
                 <Text
                   style={[
                     styles.infoText,
@@ -192,9 +199,7 @@ const SettlementInfoBox = ({
                     {backgroundColor: isDarkMode ? '#333' : 'black'},
                   ]}
                   onPress={settlementSendAlert}>
-                  <Text style={styles.sendBtnText}>
-                    송금 완료 알림을 보냅니다
-                  </Text>
+                  <Text style={styles.sendBtnText}>송금 완료</Text>
                 </TouchableOpacity>
               </>
             )}

--- a/src/screens/paxi/NewChatScreen.tsx
+++ b/src/screens/paxi/NewChatScreen.tsx
@@ -23,7 +23,7 @@ import {
   ChatRoomInfo,
   MessageData,
   PaxiUser,
-  SettlementData,
+  SettlementInfoData,
 } from '@interfaces/paxi';
 import {RootStackParamList} from '@navigation/types';
 import paxi_api from '@utils/paxi_api';
@@ -55,8 +55,8 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
   const [reconnectAttempt, setReconnectAttempt] = useState<number>(0);
   const [socketConnected, setSocketConnected] = useState<boolean>(false);
 
-  const [settlementData, setSettlementData] = useState<SettlementData>(
-    {} as SettlementData,
+  const [settlementData, setSettlementData] = useState<SettlementInfoData>(
+    {} as SettlementInfoData,
   );
   const [isSettlement, setIsSettlement] = useState<boolean>(false);
   const [isPaid, setIsPaid] = useState<boolean | undefined>(undefined);


### PR DESCRIPTION
정산 정보 모달을 변경했습니다.

### 변경사항
- 정산 공지 탭에서 ‘송금 완료 알람을 보냅니다’ 에서 ‘송금 완료’로 텍스트 변경 
- 정산 공지에 전체 정산 금액이 아닌 인당 정산 금액으로 보여주기
- 전체 금액은 하단에 따로 표기

### 스크린샷
<img width=300 src="https://github.com/user-attachments/assets/efc05021-7649-4c68-85ab-f77e8c23b6bf" />
<img width=300 src="https://github.com/user-attachments/assets/6841da1c-87ee-4fbd-bae8-eb20d0c710da" />
