### PR TITLE
Update: Trigger CI action on PR

### DIFF
--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -1,7 +1,7 @@
 on:
-  push:
-
-name: Lint
+  pull_request:
+    branches:
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
push가 아니라 PR 올릴 때 액션 돎
- 자원 절약