### PR TITLE
Fix: Keep kicked user from joining the room

### DIFF
--- a/src/components/room/RoomListCard.tsx
+++ b/src/components/room/RoomListCard.tsx
@@ -108,7 +108,7 @@ export const RoomListCard: React.FC<RoomContainerProps> = ({
       [RoomStatus.KICKED]: {
         backgroundColor: isDarkMode ? 'rgba(230,110,110,0.18)' : '#FFEEEE',
         textColor: '#E55656',
-        statusText: '강퇴됨',
+        statusText: '강퇴된 방',
       },
       [RoomStatus.JOINED]: {
         backgroundColor: isDarkMode ? 'rgba(110, 230, 24, 0.18)' : '#f1ffee',


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

https://github.com/PoApper/paxi-popo-nest-api/issues/127

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

강퇴당한 유저가 방에 다시 들어갈 수 있는 문제
백엔드 방 입장 로직은 재입장을 막도록 작동하지만, 여기서는 방 입장 엔드포인트가 아닌 채팅 로드 엔드포인트를 호출함. 이 엔드포인트에는 강퇴 검증 로직이 없어 입장 가능한 문제가 발생했음

- 따라서 프론트에서 선제적으로 강퇴된 유저의 방 입장을 막게 변경함

- 또한, 이미 참여한 유저들도 입장 시 chat 로드가 아니라 join 엔드포인트를 먼저 호출하게끔 변경함.
- 이 엔드포인트 안에서 마지막으로 읽은 메세지 정보를 저장함

### 기존

강퇴 당했지만 참여 가능 표시 및 참여도 가능
<img width="370" height="154" alt="image" src="https://github.com/user-attachments/assets/55a8001a-2b8c-445d-8315-5862dfb018be" />


### 작업 후

강퇴 UI
<img width="372" height="134" alt="image" src="https://github.com/user-attachments/assets/ddcce681-73ea-4e42-a1cd-79b5c8cfdc27" />

강퇴된 방 터치 시 막음
<img width="379" height="350" alt="image" src="https://github.com/user-attachments/assets/906b259d-8e3d-47e9-80bf-172898ae09d7" />


## ✅ 테스트 여부 체크(환경 명시) & 스크린샷

- [x] Android 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) API 36
- [x] iOS 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) iOS 18.5

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
