### PR TITLE
Update/hide kicked room from upcoming events

### DIFF
--- a/src/components/UpcomingEvents.tsx
+++ b/src/components/UpcomingEvents.tsx
@@ -275,7 +275,7 @@ const UpcomingEvents = ({refreshKey}: UpcomingEventsProps) => {
     // TODO: 방 상태 한 곳에서 관리하도록 수정
     switch (status) {
       case 'IN_SETTLEMENT':
-        return '정산중';
+        return '정산 중';
       case 'ACTIVE':
         return '출발 전';
       case 'COMPLETED':


### PR DESCRIPTION
## #️⃣ 연관된 이슈

https://github.com/PoApper/popo-mobile/issues/110



## 📝 작업 내용

사용성을 위해 메인 화면의 나의 최근 일정 탭에서 강퇴된 방을 보여주지 않음
- 내 일정 -> Paxi 에서는 강퇴된 방 및 사유 확인 가능

추가 작업들
- 다가오는 일정이란 의미에 맞게 로직, 워딩 변경
- 메인 화면에서 강퇴된 방과 더불어 종료된 방도 보여주지 않음. 정말 자신이 해야 할 "일정"을 보여주기 위한 목적 
- 카풀 상태(출발 전, 정산 중) 카드에 표시


### 기존
- 날짜 내림차순
- 아주 먼 미래의 일정도 보임

https://github.com/user-attachments/assets/8c53354f-ed72-40af-abae-1526cabef64d


### 작업 후
- 일주일 이내의 일정 오름차순
- "다가오는 일정"으로 워딩 변경
- 카풀 방 상태 표시

https://github.com/user-attachments/assets/de23bd2d-cd1d-45c3-81c5-7b43a9622902

## ✅ 테스트 여부 체크(환경 명시) & 스크린샷

- [x] Android 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) API 36
- [x] iOS 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) iOS 18.5

## 💬 리뷰 요구사항 (선택)

"출발 전" 이게 혼자 띄어쓰기 되어있어서 좀 불편하긴 하네요. 맘같아선 다 띄어쓰기하고 싶은데 코드가 쓸데없이 복잡해지는 느낌이라
TODO: 카풀 방 enum 만들어서 한 곳에서 참조하도록 변경
