### PR TITLE
Fix/android env setting stage

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,6 +13,20 @@ project.ext.envConfigFiles = [
 
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
+// env 확인용 프린트
+if (project.ext.has("env")) {
+    println "📋 로드된 환경변수:"
+    project.env.each { key, value ->
+        def displayValue = (key.toLowerCase().contains("password") ||
+                           key.toLowerCase().contains("secret") ||
+                           key.toLowerCase().contains("key") ||
+                           key.toLowerCase().contains("token"))
+            ? "***"
+            : value
+        println "  ${key} = ${displayValue}"
+    }
+    println ""
+}
 
 // START: Vector Icons
 project.ext.vectoricons = [


### PR DESCRIPTION
## #️⃣ 연관된 이슈

X



## 📝 작업 내용

.env.dev 혹은 .env.prod 가 아닌 .env 파일을 로드하는 문제 해결
.env 파일은 사용되지 않아야 함. 개발이든 릴리즈든 모든 단계에서 .env.dev 혹은 .env.prod 두 파일만 사용되어야 함


