### PR TITLE
chore: polish UI to be consistent with popo app

### DIFF
--- a/docs/deeplink/dev-room.html
+++ b/docs/deeplink/dev-room.html
@@ -34,25 +34,26 @@
         min-height: 100vh;
         margin: 0;
         padding: 20px;
-        background: linear-gradient(135deg, #fa5721 0%, #ff8a5b 100%);
-        color: white;
+        background: #ffffff;
+        color: #111827;
         text-align: center;
       }
 
       h1 {
         font-size: 24px;
         margin-bottom: 12px;
+        color: #111827;
       }
 
       p {
         font-size: 15px;
-        opacity: 0.9;
+        color: #6b7280;
         margin: 6px 0;
       }
 
       .spinner {
-        border: 3px solid rgba(255, 255, 255, 0.3);
-        border-top: 3px solid white;
+        border: 3px solid #e5e7eb;
+        border-top: 3px solid #111827;
         border-radius: 50%;
         width: 40px;
         height: 40px;
@@ -69,10 +70,10 @@
         }
       }
 
-      .button {
+      .button-primary {
         display: inline-block;
-        background: white;
-        color: #fa5721;
+        background: #111827;
+        color: #ffffff;
         padding: 12px 22px;
         border-radius: 8px;
         text-decoration: none;
@@ -80,13 +81,29 @@
         margin: 8px 4px;
       }
 
-      .button:hover {
-        background: #f3f3f3;
+      .button-primary:hover {
+        background: #1f2937;
+      }
+
+      .button-secondary {
+        display: inline-block;
+        background: #f3f4f6;
+        color: #111827;
+        padding: 12px 22px;
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 600;
+        margin: 8px 4px;
+      }
+
+      .button-secondary:hover {
+        background: #e5e7eb;
       }
 
       #status {
         margin-top: 16px;
         font-size: 14px;
+        color: #6b7280;
       }
     </style>
 
@@ -210,7 +227,7 @@
           if (spinner) spinner.style.display = 'none';
           if (statusEl) {
             statusEl.textContent = '유효하지 않은 방 링크입니다.';
-            statusEl.style.color = '#ffebee';
+            statusEl.style.color = '#EF4444';
           }
           return;
         }
@@ -290,7 +307,7 @@
     <a
       id="open-app-btn"
       href="#"
-      class="button"
+      class="button-primary"
       style="
         display: none;
         font-size: 17px;
@@ -304,12 +321,12 @@
       <p style="font-size: 13px">앱이 설치되어 있지 않다면</p>
       <a
         href="https://apps.apple.com/us/app/popo-%ED%8F%AC%EC%8A%A4%ED%85%8C%ED%82%A4%EC%95%88%EC%9D%98-%ED%95%84%EC%88%98-%EC%95%B1/id6743666761"
-        class="button">
+        class="button-secondary">
         iOS 앱 다운로드
       </a>
       <a
         href="https://play.google.com/store/apps/details?id=com.popomobile"
-        class="button">
+        class="button-secondary">
         Android 앱 다운로드
       </a>
     </div>

--- a/docs/deeplink/room.html
+++ b/docs/deeplink/room.html
@@ -33,25 +33,26 @@
         min-height: 100vh;
         margin: 0;
         padding: 20px;
-        background: linear-gradient(135deg, #fa5721 0%, #ff8a5b 100%);
-        color: white;
+        background: #ffffff;
+        color: #111827;
         text-align: center;
       }
 
       h1 {
         font-size: 24px;
         margin-bottom: 12px;
+        color: #111827;
       }
 
       p {
         font-size: 15px;
-        opacity: 0.9;
+        color: #6b7280;
         margin: 6px 0;
       }
 
       .spinner {
-        border: 3px solid rgba(255, 255, 255, 0.3);
-        border-top: 3px solid white;
+        border: 3px solid #e5e7eb;
+        border-top: 3px solid #111827;
         border-radius: 50%;
         width: 40px;
         height: 40px;
@@ -68,10 +69,10 @@
         }
       }
 
-      .button {
+      .button-primary {
         display: inline-block;
-        background: white;
-        color: #fa5721;
+        background: #111827;
+        color: #ffffff;
         padding: 12px 22px;
         border-radius: 8px;
         text-decoration: none;
@@ -79,13 +80,29 @@
         margin: 8px 4px;
       }
 
-      .button:hover {
-        background: #f3f3f3;
+      .button-primary:hover {
+        background: #1f2937;
+      }
+
+      .button-secondary {
+        display: inline-block;
+        background: #f3f4f6;
+        color: #111827;
+        padding: 12px 22px;
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 600;
+        margin: 8px 4px;
+      }
+
+      .button-secondary:hover {
+        background: #e5e7eb;
       }
 
       #status {
         margin-top: 16px;
         font-size: 14px;
+        color: #6b7280;
       }
     </style>
 
@@ -203,7 +220,7 @@
           if (spinner) spinner.style.display = 'none';
           if (statusEl) {
             statusEl.textContent = '유효하지 않은 방 링크입니다.';
-            statusEl.style.color = '#ffebee';
+            statusEl.style.color = '#EF4444';
           }
           return;
         }
@@ -283,7 +300,7 @@
     <a
       id="open-app-btn"
       href="#"
-      class="button"
+      class="button-primary"
       style="
         display: none;
         font-size: 17px;
@@ -297,12 +314,12 @@
       <p style="font-size: 13px">앱이 설치되어 있지 않다면</p>
       <a
         href="https://apps.apple.com/us/app/popo-%ED%8F%AC%EC%8A%A4%ED%85%8C%ED%82%A4%EC%95%88%EC%9D%98-%ED%95%84%EC%88%98-%EC%95%B1/id6743666761"
-        class="button">
+        class="button-secondary">
         iOS 앱 다운로드
       </a>
       <a
         href="https://play.google.com/store/apps/details?id=com.popomobile"
-        class="button">
+        class="button-secondary">
         Android 앱 다운로드
       </a>
     </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

X

### 해당 변경은 원격 서버에 반영됨. 어플리케이션에 들어가는 코드 아니지만 기록으로 남겨놓기 위함!!

## 📝 작업 내용

방 공유 브릿지 HTML 페이지 UI 포포 앱과 통일되도록 변경



### 기존

뜬금없는 주황색

### 작업 후

<img width="861" height="874" alt="image" src="https://github.com/user-attachments/assets/5c924d93-3dbe-4fa5-b9cd-1bf8e0598da3" />


## ✅ 테스트 여부 체크(환경 명시) & 스크린샷

- [x] Android 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) API 36, Android 14
- [x] iOS 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) iOS 18.5

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
