### PR TITLE
feat: disable auto capitalizing when type password

### DIFF
--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -269,6 +269,7 @@ const LoginScreen = ({navigation}: LoginScreenProps) => {
             placeholder="비밀번호"
             placeholderTextColor={placeholderColor}
             secureTextEntry
+            autoCapitalize="none"
             value={password}
             onChangeText={setPassword}
             autoComplete="password"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#227 



## 📝 작업 내용

비밀번호 타이핑 시 첫 글자 대문자 비활성

https://reactnative.dev/docs/textinput#autocapitalize

### 기존

<img width="397" height="456" alt="image" src="https://github.com/user-attachments/assets/bff96ea6-7053-4df2-a380-8e00f8b2cb4a" />


### 작업 후

<img width="379" height="392" alt="image" src="https://github.com/user-attachments/assets/71aafffa-1d3c-4844-98e0-6c487508102e" />


## ✅ 테스트 여부 체크(환경 명시) & 스크린샷

- [x] Android 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) API 36, Android 14
- [x] iOS 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) iOS 18.5

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
