### PR TITLE
build(deps): critical/high 취약점 의존성 업데이트

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8206,9 +8206,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.5.tgz",
-      "integrity": "sha512-cK9c5I/DwIOI7/Q7AlGN3DuTdwN61gwSfL8rvuVPK+0mcCNHHGxRrpiFtaZZRfRMJL3Gl8B2AFlBG6qXf03w9A==",
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
       "devOptional": true,
       "funding": [
         {
@@ -8532,9 +8532,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -11032,9 +11032,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -12755,9 +12755,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.0.tgz",
-      "integrity": "sha512-Z2E/kOY1QjoMlCytmexzYfDm/w5fKAiRwpSzGtdnXW1zC88Z2yXazHHrOtwCzn+7wSxyE8PYM4rvVcMphF9sOA==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## #️⃣ 연관된 이슈



## 📝 작업 내용

> `npm audit`에서 발견된 critical/high 취약점 의존성을 업데이트합니다.

### 기존

- `protobufjs` 7.5.0 — **Critical**: 임의 코드 실행 취약점 (GHSA-xq3m-2v4x-88gg)
- `lodash` 4.17.23 — **High**: Code Injection via `_.template` (GHSA-r5fr-rjxr-66jc), Prototype Pollution via `_.unset`/`_.omit` (GHSA-f23m-r3pf-42rh)
- `follow-redirects` 1.15.11 — Moderate: 인증 헤더 누출

### 작업 후

- `protobufjs` 7.5.5
- `lodash` 4.18.1
- `follow-redirects` 1.16.0
- `npm audit fix`로 수정, breaking change 없음

## ✅ 테스트 여부 체크(환경 명시) & 스크린샷

- [ ] Android 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) API 36, Android 14
- [ ] iOS 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) iOS 18.5

## 💬 리뷰 요구사항 (선택)

`npm audit fix`만 실행한 변경으로, `package-lock.json`만 수정되었습니다. 런타임 동작 변경은 없습니다.