### PR TITLE
feat: 학생단체 소개 탭 추가

### DIFF
--- a/src/components/student-association/StudentAssociationItem.tsx
+++ b/src/components/student-association/StudentAssociationItem.tsx
@@ -34,7 +34,8 @@ type Props = {
 const StudentAssociationItem: React.FC<Props> = ({item, onPress}) => {
   const isDarkMode = useColorScheme() === 'dark';
   const textColor = isDarkMode ? '#FFFFFF' : '#000000';
-  const hasImage = item.imageUrl && item.imageUrl.trim() !== '';
+  const hasImage =
+    item.imageUrl && item.imageUrl !== 'null' && item.imageUrl.trim() !== '';
 
   return (
     <TouchableOpacity

--- a/src/components/student-association/StudentAssociationItem.tsx
+++ b/src/components/student-association/StudentAssociationItem.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Image,
+  useColorScheme,
+} from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialIcons';
+
+export type StudentAssociationItemType = {
+  uuid: string;
+  name: string;
+  shortDesc: string;
+  content: string;
+  location: string;
+  representative: string;
+  office: string;
+  contact: string;
+  imageUrl?: string;
+  views: number;
+  homepageUrl?: string;
+  facebookUrl?: string;
+  instagramUrl?: string;
+  youtubeUrl?: string;
+};
+
+type Props = {
+  item: StudentAssociationItemType;
+  onPress: () => void;
+};
+
+const StudentAssociationItem: React.FC<Props> = ({item, onPress}) => {
+  const isDarkMode = useColorScheme() === 'dark';
+  const textColor = isDarkMode ? '#FFFFFF' : '#000000';
+  const hasImage = item.imageUrl && item.imageUrl.trim() !== '';
+
+  return (
+    <TouchableOpacity
+      style={[styles.card, {backgroundColor: isDarkMode ? '#1A1A1A' : '#fff'}]}
+      onPress={onPress}
+      activeOpacity={0.8}>
+      <View style={styles.cardContent}>
+        <View style={styles.imageContainer}>
+          {hasImage ? (
+            <Image
+              source={{uri: item.imageUrl}}
+              style={styles.image}
+              resizeMode="contain"
+            />
+          ) : (
+            <View style={styles.imagePlaceholder}>
+              <Icon
+                name="groups"
+                size={40}
+                color={isDarkMode ? '#555' : '#ccc'}
+              />
+            </View>
+          )}
+        </View>
+        <View style={styles.info}>
+          <Text style={[styles.name, {color: textColor}]} numberOfLines={1}>
+            {item.name}
+          </Text>
+          <Text
+            style={[styles.description, {color: isDarkMode ? '#888' : '#666'}]}
+            numberOfLines={2}>
+            {item.shortDesc}
+          </Text>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default StudentAssociationItem;
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 12,
+    borderRadius: 12,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 6,
+    padding: 12,
+  },
+  cardContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  imageContainer: {
+    width: 100,
+    height: 100,
+    borderRadius: 8,
+    overflow: 'hidden',
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  image: {
+    padding: 10,
+    width: '100%',
+    height: '100%',
+  },
+  imagePlaceholder: {
+    width: '100%',
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F0F0F0',
+  },
+  info: {
+    flex: 1,
+    marginLeft: 16,
+  },
+  name: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  description: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+});

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -46,6 +46,8 @@ import ClubScreen from '@screens/club/ClubScreen';
 import ClubDetailScreen from '@screens/club/ClubDetailScreen';
 import AssociationScreen from '@screens/association/AssociationScreen';
 import AssociationDetailScreen from '@screens/association/AssociationDetailScreen';
+import StudentAssociationScreen from '@screens/student-association/StudentAssociationScreen';
+import StudentAssociationDetailScreen from '@screens/student-association/StudentAssociationDetailScreen';
 
 // Other Screens
 import WhitebookScreen from '@screens/WhitebookScreen';
@@ -187,6 +189,14 @@ const AppNavigator = () => {
           <Stack.Screen
             name="AssociationDetail"
             component={AssociationDetailScreen}
+          />
+          <Stack.Screen
+            name="StudentAssociation"
+            component={StudentAssociationScreen}
+          />
+          <Stack.Screen
+            name="StudentAssociationDetail"
+            component={StudentAssociationDetailScreen}
           />
 
           {/* Other Screens */}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -7,6 +7,7 @@ export type RootStackParamList = AuthStackParamList &
   PlaceReservationStackParamList &
   ClubStackParamList &
   AssociationStackParamList &
+  StudentAssociationStackParamList &
   OtherStackParamList;
 
 export type AuthStackParamList = {
@@ -66,6 +67,13 @@ export type AssociationStackParamList = {
   AssociationDetail: {
     associationId: string;
     associationName: string;
+  };
+};
+
+export type StudentAssociationStackParamList = {
+  StudentAssociation: undefined;
+  StudentAssociationDetail: {
+    studentAssociationName: string;
   };
 };
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -152,20 +152,27 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
     },
     {
       id: '5',
+      icon: 'groups',
+      title: '학생단체',
+      active: true,
+      onPress: () => navigation.navigate('StudentAssociation'),
+    },
+    {
+      id: '6',
       icon: 'menu-book',
       title: '생활백서',
       active: true,
       onPress: () => navigation.navigate('Whitebook'),
     },
     {
-      id: '6',
+      id: '7',
       icon: 'store',
       title: '제휴업체',
       active: true,
       onPress: () => navigation.navigate('Benefits'),
     },
     {
-      id: '7',
+      id: '8',
       icon: 'dining',
       title: '배달업체',
       active: true,
@@ -187,7 +194,7 @@ const HomeScreen = ({navigation}: HomeScreenProps) => {
       },
     },
     {
-      id: '8',
+      id: '9',
       icon: 'description',
       title: '기록물관리',
       active: true,

--- a/src/screens/student-association/StudentAssociationDetailScreen.tsx
+++ b/src/screens/student-association/StudentAssociationDetailScreen.tsx
@@ -1,0 +1,349 @@
+import React, {useEffect, useState} from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Image,
+  useColorScheme,
+  StatusBar,
+  TouchableOpacity,
+  Linking,
+} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {RouteProp} from '@react-navigation/native';
+import Icon from 'react-native-vector-icons/MaterialIcons';
+
+import {RootStackParamList} from '@navigation/types';
+import api from '@utils/api';
+import CommonHeader from '@components/CommonHeader';
+
+type StudentAssociationDetailScreenProps = {
+  navigation: NativeStackNavigationProp<
+    RootStackParamList,
+    'StudentAssociationDetail'
+  >;
+  route: RouteProp<RootStackParamList, 'StudentAssociationDetail'>;
+};
+
+interface StudentAssociationDetail {
+  uuid: string;
+  name: string;
+  shortDesc: string;
+  content: string;
+  location: string;
+  representative: string;
+  office: string;
+  contact: string;
+  imageUrl?: string;
+  views: number;
+  homepageUrl?: string;
+  facebookUrl?: string;
+  instagramUrl?: string;
+  youtubeUrl?: string;
+}
+
+const StudentAssociationDetailScreen: React.FC<
+  StudentAssociationDetailScreenProps
+> = ({navigation, route}) => {
+  const isDarkMode = useColorScheme() === 'dark';
+  const [data, setData] = useState<StudentAssociationDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const {studentAssociationName} = route.params;
+
+  useEffect(() => {
+    const fetchDetail = async () => {
+      try {
+        const response = await api.get<StudentAssociationDetail>(
+          `/introduce/student_association/name/${encodeURIComponent(
+            studentAssociationName,
+          )}`,
+        );
+        setData(response.data);
+      } catch (error) {
+        console.error('학생단체 상세 정보 로드 오류:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchDetail();
+  }, [studentAssociationName]);
+
+  const backgroundStyle = {
+    backgroundColor: isDarkMode ? '#121212' : '#fff',
+    flex: 1,
+  };
+
+  const textColor = isDarkMode ? '#FFFFFF' : '#000000';
+  const borderColor = isDarkMode ? '#2C2C2C' : '#E5E7EB';
+
+  const handleLinkPress = async (url: string) => {
+    if (url) {
+      try {
+        await Linking.openURL(url);
+      } catch (error) {
+        console.error('링크 열기 오류:', error);
+      }
+    }
+  };
+
+  const isValidUrl = (url?: string) =>
+    url && url !== 'null' && url.trim() !== '';
+
+  if (isLoading) {
+    return (
+      <SafeAreaView style={backgroundStyle}>
+        <CommonHeader navigation={navigation} title={studentAssociationName} />
+        <View style={styles.loadingContainer}>
+          <Text style={[styles.loadingText, {color: textColor}]}>
+            로딩중...
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={backgroundStyle}>
+      <StatusBar
+        barStyle={isDarkMode ? 'light-content' : 'dark-content'}
+        backgroundColor={backgroundStyle.backgroundColor}
+      />
+      <CommonHeader navigation={navigation} title={studentAssociationName} />
+
+      <ScrollView style={styles.container}>
+        {data && (
+          <>
+            <View style={styles.imageContainer}>
+              {data.imageUrl && data.imageUrl.trim() !== '' ? (
+                <Image
+                  source={{uri: data.imageUrl}}
+                  style={styles.image}
+                  resizeMode="contain"
+                />
+              ) : (
+                <View style={styles.imagePlaceholder}>
+                  <Icon name="groups" size={60} color="#ccc" />
+                </View>
+              )}
+            </View>
+            <View style={styles.contentContainer}>
+              <Text style={[styles.name, {color: textColor}]}>{data.name}</Text>
+              <Text
+                style={[
+                  styles.shortDesc,
+                  {color: isDarkMode ? '#999' : '#666'},
+                ]}>
+                {data.shortDesc}
+              </Text>
+
+              <View style={[styles.infoSection, {borderColor}]}>
+                <Text
+                  style={[
+                    styles.content,
+                    {color: isDarkMode ? '#888' : '#666'},
+                  ]}>
+                  {data.content}
+                </Text>
+              </View>
+
+              <View style={[styles.infoSection, {borderColor}]}>
+                {data.location?.trim() !== '' && (
+                  <View style={styles.infoRow}>
+                    <Text style={[styles.infoLabel, {color: textColor}]}>
+                      사무실 위치
+                    </Text>
+                    <Text
+                      style={[
+                        styles.infoValue,
+                        {color: isDarkMode ? '#888' : '#666'},
+                      ]}>
+                      {data.location}
+                    </Text>
+                  </View>
+                )}
+                {data.office?.trim() !== '' && (
+                  <View style={styles.infoRow}>
+                    <Text style={[styles.infoLabel, {color: textColor}]}>
+                      협력 행정팀
+                    </Text>
+                    <Text
+                      style={[
+                        styles.infoValue,
+                        {color: isDarkMode ? '#888' : '#666'},
+                      ]}>
+                      {data.office}
+                    </Text>
+                  </View>
+                )}
+                <View style={styles.infoRow}>
+                  <Text style={[styles.infoLabel, {color: textColor}]}>
+                    대표자
+                  </Text>
+                  <Text
+                    style={[
+                      styles.infoValue,
+                      {color: isDarkMode ? '#888' : '#666'},
+                    ]}>
+                    {data.representative}
+                  </Text>
+                </View>
+                <View style={styles.infoRow}>
+                  <Text style={[styles.infoLabel, {color: textColor}]}>
+                    연락처
+                  </Text>
+                  <Text
+                    style={[
+                      styles.infoValue,
+                      {color: isDarkMode ? '#888' : '#666'},
+                    ]}>
+                    {data.contact}
+                  </Text>
+                </View>
+              </View>
+
+              <View style={[styles.infoSection, {borderColor}]}>
+                <View style={styles.socialLinks}>
+                  {isValidUrl(data.homepageUrl) && (
+                    <TouchableOpacity
+                      style={[
+                        styles.socialButton,
+                        {backgroundColor: '#000000'},
+                      ]}
+                      onPress={() => handleLinkPress(data.homepageUrl!)}>
+                      <Text style={styles.socialText}>홈페이지</Text>
+                    </TouchableOpacity>
+                  )}
+                  {isValidUrl(data.facebookUrl) && (
+                    <TouchableOpacity
+                      style={[
+                        styles.socialButton,
+                        {backgroundColor: '#1877F2'},
+                      ]}
+                      onPress={() => handleLinkPress(data.facebookUrl!)}>
+                      <Text style={styles.socialText}>Facebook</Text>
+                    </TouchableOpacity>
+                  )}
+                  {isValidUrl(data.instagramUrl) && (
+                    <TouchableOpacity
+                      style={[
+                        styles.socialButton,
+                        {backgroundColor: '#E4405F'},
+                      ]}
+                      onPress={() => handleLinkPress(data.instagramUrl!)}>
+                      <Text style={styles.socialText}>Instagram</Text>
+                    </TouchableOpacity>
+                  )}
+                  {isValidUrl(data.youtubeUrl) && (
+                    <TouchableOpacity
+                      style={[
+                        styles.socialButton,
+                        {backgroundColor: '#FF0000'},
+                      ]}
+                      onPress={() => handleLinkPress(data.youtubeUrl!)}>
+                      <Text style={styles.socialText}>YouTube</Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              </View>
+            </View>
+          </>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingText: {
+    fontSize: 16,
+  },
+  imageContainer: {
+    width: '100%',
+    height: 250,
+    backgroundColor: '#fff',
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+    marginBottom: 24,
+  },
+  image: {
+    padding: 10,
+    width: '100%',
+    height: '100%',
+  },
+  imagePlaceholder: {
+    width: '100%',
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F0F0F0',
+  },
+  contentContainer: {
+    padding: 24,
+  },
+  name: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  shortDesc: {
+    fontSize: 16,
+    marginBottom: 12,
+  },
+  infoSection: {
+    borderTopWidth: 1,
+    paddingVertical: 24,
+  },
+  content: {
+    fontSize: 16,
+    lineHeight: 24,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    marginBottom: 12,
+  },
+  infoLabel: {
+    width: 90,
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  infoValue: {
+    flex: 1,
+    fontSize: 16,
+  },
+  socialLinks: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingVertical: 8,
+  },
+  socialButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 8,
+    marginHorizontal: 4,
+    marginVertical: 4,
+    minWidth: 100,
+  },
+  socialText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+});
+
+export default StudentAssociationDetailScreen;

--- a/src/screens/student-association/StudentAssociationDetailScreen.tsx
+++ b/src/screens/student-association/StudentAssociationDetailScreen.tsx
@@ -8,7 +8,6 @@ import {
   useColorScheme,
   StatusBar,
   TouchableOpacity,
-  Linking,
 } from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
@@ -17,6 +16,7 @@ import Icon from 'react-native-vector-icons/MaterialIcons';
 
 import {RootStackParamList} from '@navigation/types';
 import api from '@utils/api';
+import {openURLWithFallback} from '@utils/linking';
 import CommonHeader from '@components/CommonHeader';
 
 type StudentAssociationDetailScreenProps = {
@@ -80,18 +80,8 @@ const StudentAssociationDetailScreen: React.FC<
   const textColor = isDarkMode ? '#FFFFFF' : '#000000';
   const borderColor = isDarkMode ? '#2C2C2C' : '#E5E7EB';
 
-  const handleLinkPress = async (url: string) => {
-    if (url) {
-      try {
-        await Linking.openURL(url);
-      } catch (error) {
-        console.error('링크 열기 오류:', error);
-      }
-    }
-  };
-
-  const isValidUrl = (url?: string) =>
-    url && url !== 'null' && url.trim() !== '';
+  const hasValue = (value?: string) =>
+    value && value !== 'null' && value.trim() !== '';
 
   if (isLoading) {
     return (
@@ -118,7 +108,7 @@ const StudentAssociationDetailScreen: React.FC<
         {data && (
           <>
             <View style={styles.imageContainer}>
-              {data.imageUrl && data.imageUrl.trim() !== '' ? (
+              {hasValue(data.imageUrl) ? (
                 <Image
                   source={{uri: data.imageUrl}}
                   style={styles.image}
@@ -151,7 +141,7 @@ const StudentAssociationDetailScreen: React.FC<
               </View>
 
               <View style={[styles.infoSection, {borderColor}]}>
-                {data.location?.trim() !== '' && (
+                {hasValue(data.location) && (
                   <View style={styles.infoRow}>
                     <Text style={[styles.infoLabel, {color: textColor}]}>
                       사무실 위치
@@ -165,7 +155,7 @@ const StudentAssociationDetailScreen: React.FC<
                     </Text>
                   </View>
                 )}
-                {data.office?.trim() !== '' && (
+                {hasValue(data.office) && (
                   <View style={styles.infoRow}>
                     <Text style={[styles.infoLabel, {color: textColor}]}>
                       협력 행정팀
@@ -207,43 +197,43 @@ const StudentAssociationDetailScreen: React.FC<
 
               <View style={[styles.infoSection, {borderColor}]}>
                 <View style={styles.socialLinks}>
-                  {isValidUrl(data.homepageUrl) && (
+                  {hasValue(data.homepageUrl) && (
                     <TouchableOpacity
                       style={[
                         styles.socialButton,
                         {backgroundColor: '#000000'},
                       ]}
-                      onPress={() => handleLinkPress(data.homepageUrl!)}>
+                      onPress={() => openURLWithFallback(data.homepageUrl!)}>
                       <Text style={styles.socialText}>홈페이지</Text>
                     </TouchableOpacity>
                   )}
-                  {isValidUrl(data.facebookUrl) && (
+                  {hasValue(data.facebookUrl) && (
                     <TouchableOpacity
                       style={[
                         styles.socialButton,
                         {backgroundColor: '#1877F2'},
                       ]}
-                      onPress={() => handleLinkPress(data.facebookUrl!)}>
+                      onPress={() => openURLWithFallback(data.facebookUrl!)}>
                       <Text style={styles.socialText}>Facebook</Text>
                     </TouchableOpacity>
                   )}
-                  {isValidUrl(data.instagramUrl) && (
+                  {hasValue(data.instagramUrl) && (
                     <TouchableOpacity
                       style={[
                         styles.socialButton,
                         {backgroundColor: '#E4405F'},
                       ]}
-                      onPress={() => handleLinkPress(data.instagramUrl!)}>
+                      onPress={() => openURLWithFallback(data.instagramUrl!)}>
                       <Text style={styles.socialText}>Instagram</Text>
                     </TouchableOpacity>
                   )}
-                  {isValidUrl(data.youtubeUrl) && (
+                  {hasValue(data.youtubeUrl) && (
                     <TouchableOpacity
                       style={[
                         styles.socialButton,
                         {backgroundColor: '#FF0000'},
                       ]}
-                      onPress={() => handleLinkPress(data.youtubeUrl!)}>
+                      onPress={() => openURLWithFallback(data.youtubeUrl!)}>
                       <Text style={styles.socialText}>YouTube</Text>
                     </TouchableOpacity>
                   )}

--- a/src/screens/student-association/StudentAssociationScreen.tsx
+++ b/src/screens/student-association/StudentAssociationScreen.tsx
@@ -1,0 +1,187 @@
+import React, {useEffect, useState} from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  useColorScheme,
+  StatusBar,
+  TouchableOpacity,
+} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+
+import {RootStackParamList} from '@navigation/types';
+import api from '@utils/api';
+import CommonHeader from '@components/CommonHeader';
+import StudentAssociationItem, {
+  StudentAssociationItemType,
+} from '@components/student-association/StudentAssociationItem';
+
+type StudentAssociationScreenProps = {
+  navigation: NativeStackNavigationProp<
+    RootStackParamList,
+    'StudentAssociation'
+  >;
+};
+
+const sortTypes = ['가나다순', '조회순'];
+
+const StudentAssociationScreen: React.FC<StudentAssociationScreenProps> = ({
+  navigation,
+}) => {
+  const isDarkMode = useColorScheme() === 'dark';
+  const [sortType, setSortType] = useState('가나다순');
+  const [isLoading, setIsLoading] = useState(true);
+  const [studentAssociations, setStudentAssociations] = useState<
+    StudentAssociationItemType[]
+  >([]);
+
+  const backgroundStyle = {
+    backgroundColor: isDarkMode ? '#121212' : '#fff',
+    flex: 1,
+  };
+
+  const textColor = isDarkMode ? '#FFFFFF' : '#000000';
+
+  const getSortedItems = (items: StudentAssociationItemType[]) => {
+    if (sortType === '가나다순') {
+      return [...items].sort((a, b) => a.name.localeCompare(b.name));
+    } else {
+      return [...items].sort((a, b) => b.views - a.views);
+    }
+  };
+
+  useEffect(() => {
+    const fetchStudentAssociations = async () => {
+      try {
+        const response = await api.get<StudentAssociationItemType[]>(
+          '/introduce/student_association',
+        );
+        setStudentAssociations(response.data);
+      } catch (error) {
+        console.error('학생단체 데이터 로드 오류:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchStudentAssociations();
+  }, []);
+
+  const renderItem = ({item}: {item: StudentAssociationItemType}) => {
+    return (
+      <StudentAssociationItem
+        item={item}
+        onPress={() =>
+          navigation.navigate('StudentAssociationDetail', {
+            studentAssociationName: item.name,
+          })
+        }
+      />
+    );
+  };
+
+  const ListEmpty = () => {
+    return (
+      <View
+        style={[
+          styles.emptyContainer,
+          isDarkMode ? styles.cardDark : styles.cardLight,
+        ]}>
+        <Text style={[styles.emptyText, {color: textColor}]}>
+          {isLoading ? '로딩중...' : '등록된 학생단체가 없습니다.'}
+        </Text>
+      </View>
+    );
+  };
+
+  return (
+    <SafeAreaView style={backgroundStyle}>
+      <StatusBar
+        barStyle={isDarkMode ? 'light-content' : 'dark-content'}
+        backgroundColor={backgroundStyle.backgroundColor}
+      />
+      <CommonHeader navigation={navigation} title="학생단체" />
+
+      <View style={styles.sortButtons}>
+        {sortTypes.map(type => (
+          <TouchableOpacity
+            key={type}
+            style={[
+              styles.sortButton,
+              {borderColor: isDarkMode ? '#555' : '#ccc'},
+              sortType === type && [
+                styles.activeSort,
+                {backgroundColor: textColor},
+              ],
+            ]}
+            onPress={() => setSortType(type)}>
+            <Text
+              style={[
+                styles.sortButtonText,
+                {color: textColor},
+                sortType === type && {color: isDarkMode ? '#000' : '#fff'},
+              ]}>
+              {type}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <FlatList
+        style={styles.container}
+        contentContainerStyle={styles.listContent}
+        data={getSortedItems(studentAssociations)}
+        keyExtractor={item => item.uuid}
+        renderItem={renderItem}
+        ListEmptyComponent={ListEmpty}
+        showsVerticalScrollIndicator={false}
+      />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+  },
+  listContent: {
+    paddingBottom: 20,
+  },
+  sortButtons: {
+    flexDirection: 'row',
+    paddingHorizontal: 15,
+    marginVertical: 10,
+    gap: 8,
+  },
+  sortButton: {
+    paddingHorizontal: 15,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1,
+  },
+  activeSort: {
+    borderColor: '#000',
+  },
+  sortButtonText: {
+    fontSize: 14,
+  },
+  emptyContainer: {
+    padding: 16,
+    borderRadius: 12,
+  },
+  cardDark: {
+    backgroundColor: '#1A1A1A',
+  },
+  cardLight: {
+    backgroundColor: '#fff',
+  },
+  emptyText: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+});
+
+export default StudentAssociationScreen;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- PoApper/popo-public-web#170 참고

## 📝 작업 내용

> popo-public-web에 추가된 학생단체(Student Association) 소개 기능을 모바일 앱에도 구현

### 기존

- 홈 화면에 동아리, 자치단체 소개만 존재
- 학생단체(학생단체) 소개 화면 없음

### 작업 후

- 학생단체 목록 화면 추가 (`GET /introduce/student_association`)
  - 가나다순 / 조회순 정렬
  - 이미지 없을 때 placeholder 아이콘 표시
- 학생단체 상세 화면 추가 (`GET /introduce/student_association/name/{name}`)
  - 이미지, 이름, 짧은 소개(shortDesc), 본문(content)
  - 사무실 위치(location), 협력 행정팀(office) — 빈 값이면 숨김
  - 대표자, 연락처, 소셜 링크(홈페이지/Facebook/Instagram/YouTube)
- 네비게이션 타입 및 라우트 등록
- 홈 화면 서비스 그리드에 "학생단체" 바로가기 추가

## ✅ 테스트 여부 체크(환경 명시) & 스크린샷

<img width="913" height="989" alt="image" src="https://github.com/user-attachments/assets/de6cb51c-1e4e-4740-8b71-263b64535fa4" />

<img width="927" height="963" alt="image" src="https://github.com/user-attachments/assets/f7f32a20-6e36-47e5-8f41-b5215529428d" />

<img width="926" height="979" alt="image" src="https://github.com/user-attachments/assets/c104d759-681e-4976-9e77-112a59266188" />


- [x] Android 환경에서 빌드 및 앱 실행 확인. 환경) emulator-5554
- [x] iOS 환경에서 빌드 및 앱 실행 확인. 환경) iPhone Air Simulator, iOS 26.2

## 💬 리뷰 요구사항 (선택)

- 백엔드 API(`introduce/student_association`)가 배포되어 있어야 실제 데이터 확인 가능
- 상세 화면은 웹 PR과 동일하게 name 기반 조회 사용 (UUID 아님)