### PR TITLE
refactor: P1 리팩토링 — moment locale 중앙화, 호출 규약·중복 함수 정리 (#244 #262 #235)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,16 @@
  */
 
 import {AppRegistry} from 'react-native';
+import moment from 'moment';
+import 'moment/locale/ko';
 import App from './App';
 import {name as appName} from './app.json';
 import messaging from '@react-native-firebase/messaging';
 import EncryptedStorage from 'react-native-encrypted-storage';
+
+// Moment 로케일은 앱 진입점에서 한 번만 설정한다.
+// 개별 UI 컴포넌트에서 side-effect import 하지 않도록 중앙화 (#244)
+moment.locale('ko');
 
 // NOTE: deeplink queueing
 messaging()

--- a/index.js
+++ b/index.js
@@ -10,8 +10,7 @@ import {name as appName} from './app.json';
 import messaging from '@react-native-firebase/messaging';
 import EncryptedStorage from 'react-native-encrypted-storage';
 
-// Moment 로케일은 앱 진입점에서 한 번만 설정한다.
-// 개별 UI 컴포넌트에서 side-effect import 하지 않도록 중앙화 (#244)
+// Moment 로케일은 앱 진입점에서 한 번만 설정
 moment.locale('ko');
 
 // NOTE: deeplink queueing

--- a/src/components/chat/RoomInfoBox.tsx
+++ b/src/components/chat/RoomInfoBox.tsx
@@ -9,7 +9,6 @@ import {
 } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import moment from 'moment';
-import 'moment/locale/ko';
 import Svg, {Line} from 'react-native-svg';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {RootStackParamList} from '@navigation/types';
@@ -39,9 +38,9 @@ const RoomInfoBox = ({
 
   const handleShare = async () => {
     try {
-      const departureDate = moment(roomData.departureTime)
-        .locale('ko')
-        .format('M/D(ddd) HH:mm');
+      const departureDate = moment(roomData.departureTime).format(
+        'M/D(ddd) HH:mm',
+      );
       const shareMessage = `${departureDate} ${roomData.departureLocation}→${roomData.destinationLocation}\n${shareUrl}`;
       await Share.share({message: shareMessage});
     } catch (error: any) {

--- a/src/screens/paxi/CreatePaxiRoomScreen.tsx
+++ b/src/screens/paxi/CreatePaxiRoomScreen.tsx
@@ -22,6 +22,7 @@ import {
   getPaxiDurationInfo,
   PAXI_LOCATIONS,
 } from '@utils/locations';
+import {roundUpToNearest10Minutes} from '@utils/popo-datetime';
 import CommonHeader from '@components/CommonHeader';
 import DropdownMenu from '@components/room/DropdownMenu';
 
@@ -39,12 +40,6 @@ interface NewRoomBody {
   departureLocation: string;
   destinationLocation: string;
   maxParticipant: number;
-}
-
-// 10분 단위로 올림
-function roundUpToNearest10Minutes(date: Date) {
-  const ms = 1000 * 60 * 10;
-  return new Date(Math.ceil(date.getTime() / ms) * ms);
 }
 
 const CreatePaxiRoomScreen = ({navigation}: CreatePaxiRoomScreenProps) => {

--- a/src/screens/paxi/ModifyPaxiRoomScreen.tsx
+++ b/src/screens/paxi/ModifyPaxiRoomScreen.tsx
@@ -25,6 +25,7 @@ import {
 import CommonHeader from '@components/CommonHeader';
 import DropdownMenu from '@components/room/DropdownMenu';
 import {RouteProp, useRoute} from '@react-navigation/native';
+import {roundUpToNearest10Minutes} from '@utils/popo-datetime';
 
 type ModifyPaxiRoomScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'ModifyPaxiRoom'>;
@@ -37,12 +38,6 @@ interface ModifyRoomBody {
   departureLocation: string;
   destinationLocation: string;
   maxParticipant: number;
-}
-
-// 10분 단위로 올림
-function roundUpToNearest10Minutes(date: Date) {
-  const ms = 1000 * 60 * 10;
-  return new Date(Math.ceil(date.getTime() / ms) * ms);
 }
 
 type SettlementScreenRouteProp = RouteProp<

--- a/src/screens/paxi/PaxiRoomListScreen.tsx
+++ b/src/screens/paxi/PaxiRoomListScreen.tsx
@@ -60,8 +60,7 @@ const PaxiRoomListScreen = ({navigation}: PaxiRoomListScreenProps) => {
    * 방 목록을 조회해 state에 반영한다.
    *
    * 에러를 자체적으로 처리하지 않고 그대로 throw 하므로,
-   * **호출처에서 반드시 try/catch로 감싸 처리해야 한다.**
-   * (호출 컨텍스트마다 다른 사용자 메시지를 보여주기 위해 의도적으로 위임 — #262)
+   * 호출처에서 반드시 try/catch로 감싸 처리해야 한다.
    *
    * @throws 네트워크/서버 오류 시 axios 에러를 그대로 전파
    */

--- a/src/screens/paxi/PaxiRoomListScreen.tsx
+++ b/src/screens/paxi/PaxiRoomListScreen.tsx
@@ -56,6 +56,15 @@ const PaxiRoomListScreen = ({navigation}: PaxiRoomListScreenProps) => {
     flex: 1,
   };
 
+  /**
+   * 방 목록을 조회해 state에 반영한다.
+   *
+   * 에러를 자체적으로 처리하지 않고 그대로 throw 하므로,
+   * **호출처에서 반드시 try/catch로 감싸 처리해야 한다.**
+   * (호출 컨텍스트마다 다른 사용자 메시지를 보여주기 위해 의도적으로 위임 — #262)
+   *
+   * @throws 네트워크/서버 오류 시 axios 에러를 그대로 전파
+   */
   const getRoomList = async () => {
     const res = await paxi_api.get('/room');
     setRoomData(res.data);

--- a/src/utils/__tests__/popo-datetime.test.ts
+++ b/src/utils/__tests__/popo-datetime.test.ts
@@ -1,4 +1,7 @@
-import {formatReservationTime} from '../popo-datetime';
+import {
+  formatReservationTime,
+  roundUpToNearest10Minutes,
+} from '../popo-datetime';
 
 describe('formatReservationTime', () => {
   it('HHMM 형식 문자열을 HH:MM으로 변환한다', () => {
@@ -20,5 +23,28 @@ describe('formatReservationTime', () => {
 
     // 숫자가 아닌 문자열인 경우
     expect(formatReservationTime('abcd')).toBe('ab:cd');
+  });
+});
+
+describe('roundUpToNearest10Minutes', () => {
+  it('10분 단위가 아닌 시각을 다음 10분 경계로 올림한다', () => {
+    expect(roundUpToNearest10Minutes(new Date('2026-06-07T10:03:00'))).toEqual(
+      new Date('2026-06-07T10:10:00'),
+    );
+    expect(roundUpToNearest10Minutes(new Date('2026-06-07T10:09:59'))).toEqual(
+      new Date('2026-06-07T10:10:00'),
+    );
+  });
+
+  it('이미 10분 경계에 있으면 그대로 유지한다', () => {
+    expect(roundUpToNearest10Minutes(new Date('2026-06-07T10:10:00'))).toEqual(
+      new Date('2026-06-07T10:10:00'),
+    );
+  });
+
+  it('시(hour) 경계를 넘겨 올림한다', () => {
+    expect(roundUpToNearest10Minutes(new Date('2026-06-07T10:55:30'))).toEqual(
+      new Date('2026-06-07T11:00:00'),
+    );
   });
 });

--- a/src/utils/popo-datetime.ts
+++ b/src/utils/popo-datetime.ts
@@ -1,3 +1,12 @@
 export const formatReservationTime = (time: string) => {
   return time.slice(0, 2) + ':' + time.slice(2, 4);
 };
+
+const TEN_MINUTES_IN_MS = 1000 * 60 * 10;
+
+/** 주어진 시각을 다음 10분 경계로 올림한다 (이미 경계면 그대로). */
+export function roundUpToNearest10Minutes(date: Date): Date {
+  return new Date(
+    Math.ceil(date.getTime() / TEN_MINUTES_IN_MS) * TEN_MINUTES_IN_MS,
+  );
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#244, #262, #235 (부분)

> **변경 안내:** 본래 포함했던 **#234(환경별 logger 도입)은 제외**했습니다.
> 프로덕션 console 제거는 이미 `babel.config.js`의 `transform-remove-console`(`exclude: ['error','warn']`, #271에서 추가)가 처리하고 있어, logger 추상화는 기능적으로 중복이고 `warn` 정책과는 오히려 상충했습니다. `console.*` + babel 일임 방식(B안)으로 정리했습니다.

## 📝 작업 내용

> P1 우선순위 리팩토링. 각 이슈를 논리적 커밋 단위로 분리해 처리.

### 기존

- moment 로케일을 `RoomInfoBox.tsx`에서 side-effect import(`moment/locale/ko`) + 인라인 `.locale('ko')`로 설정 — 모듈 로드 순서에 의존
- `getRoomList`이 에러를 throw만 하고 호출 규약이 코드에 명시되지 않음
- `roundUpToNearest10Minutes`가 Create/ModifyPaxiRoomScreen에 중복 정의

### 작업 후

- **#244**: `index.js`에서 `moment.locale('ko')`로 앱 진입 시 1회 설정, 컴포넌트의 side-effect import 제거
- **#262**: `getRoomList`에 "호출처 try/catch 필수" JSDoc 규약 명시 (동작 무변경)
- **#235**: 중복 `roundUpToNearest10Minutes`를 `popo-datetime.ts`로 이동, 매직넘버 `1000*60*10`을 `TEN_MINUTES_IN_MS` 상수화 + TDD 테스트 추가

## ✅ 테스트 여부 체크(환경 명시) & 스크린샷

- [ ] Android 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) API 36, Android 14
- [ ] iOS 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) iOS 18.5

자동 검증: `tsc`(신규 에러 0, 기존 베이스라인 3건 유지), `eslint` 통과(0 errors), `jest` 22/22 통과.

## 💬 리뷰 요구사항 (선택)

- **#235는 부분 처리**입니다. 남은 순수 리팩토링(날짜 포맷 문자열 중앙화, 페이지네이션/스크롤 매직넘버 상수화, UpcomingEvents 리팩토링 TODO)은 후속으로 남겼습니다.
- #235에 섞여 있던 **동작 변경/기능 TODO는 별도 이슈로 분리**했습니다: #290(정산 취소 문구), #291(신고 사유 모달), 웹소켓 토큰 갱신은 #199에 연결.
- catch 블록 내 `error.response.data.message` 직접 접근으로 인한 잠재 TypeError 크래시는 #294로 분리했습니다.
