### PR TITLE
feat: 채팅 소켓 토큰 만료 재연결 및 끊김 안내 개선

### DIFF
--- a/docs/superpowers/plans/2026-07-12-websocket-token-expiry-reconnect.md
+++ b/docs/superpowers/plans/2026-07-12-websocket-token-expiry-reconnect.md
@@ -1,0 +1,498 @@
+# WebSocket 토큰 만료 재연결 — 인증 확정 신호 + 재연결 실패 안내 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 서버가 인증 성공 시 `connected` 이벤트를 보내고, 클라이언트가 이 이벤트로만 재인증 카운터를 리셋해 무한 재연결 루프를 막고, 재연결 상한 도달 시 명확한 종료 안내를 표시한다.
+
+**Architecture:** 서버 `ChatGateway.handleConnection`은 소켓 연결이 성립된 뒤 실행되므로 전송 계층 `connect`는 인증 확정이 아니다. 서버가 토큰 검증 성공 후 `connected` 이벤트를 emit하고, 클라이언트는 이 이벤트에 `onSocketConnected`를 바인딩한다. 재연결 상한 도달 시 `onGiveUp` 콜백으로 UI에 종료 상태를 알리고, 재입장(포커스) 시 가드를 초기화해 복구한다.
+
+**Tech Stack:** NestJS + socket.io(서버), React Native + socket.io-client + Jest(클라이언트). 두 저장소에 걸친 변경.
+
+**저장소 / 브랜치:**
+- 서버: `~/university_life/PoApper/paxi-popo-nest-api`, 브랜치 `refactor/websocket-error-event`
+- 클라이언트: `~/university_life/PoApper/popo-mobile/.worktrees/ws-token-refresh`, 브랜치 `feat/websocket-token-refresh`
+
+**설계 문서:** `docs/superpowers/specs/2026-07-12-websocket-token-expiry-reconnect-design.md`
+
+**배포 순서 주의:** 클라이언트가 서버의 `connected` emit에 의존한다. 서버 배포가 선행되거나 동시여야 하며, 두 PR은 세트로 머지한다.
+
+---
+
+## File Structure
+
+**서버 (paxi-popo-nest-api):**
+- Modify: `src/chat/chat.events.ts` — `CONNECTED` 이벤트 상수 추가
+- Modify: `src/chat/chat.gateway.ts` — 인증 성공 시 `connected` emit
+- Create: `src/chat/chat.gateway.spec.ts` — `handleConnection` 단위 테스트
+
+**클라이언트 (popo-mobile):**
+- Modify: `src/constants/socket-events.ts` — `CONNECTED` 상수 추가(서버와 일치)
+- Modify: `src/utils/socket-factory.ts` — 전송 `connect`는 로그만, `connected`에 `onSocketConnected` 바인딩
+- Modify: `src/utils/__tests__/socket-factory.test.ts` — `connected` 배선 테스트로 갱신
+- Modify: `src/utils/socket-reauth.ts` — `onGiveUp` 콜백 추가
+- Modify: `src/utils/__tests__/socket-reauth.test.ts` — `onGiveUp` 테스트 추가
+- Modify: `src/screens/paxi/NewChatScreen.tsx` — `reconnectFailed` 상태 / 배너 / 포커스 가드 초기화
+
+---
+
+## Task 1: 서버 — 인증 성공 시 `connected` 이벤트 emit
+
+**Files:**
+- Modify: `~/university_life/PoApper/paxi-popo-nest-api/src/chat/chat.events.ts`
+- Modify: `~/university_life/PoApper/paxi-popo-nest-api/src/chat/chat.gateway.ts` (성공 경로, `client.join` 직후)
+- Create: `~/university_life/PoApper/paxi-popo-nest-api/src/chat/chat.gateway.spec.ts`
+
+- [ ] **Step 1: 서버 브랜치 체크아웃**
+
+Run:
+```bash
+cd ~/university_life/PoApper/paxi-popo-nest-api && git checkout refactor/websocket-error-event
+```
+Expected: `refactor/websocket-error-event` 브랜치로 전환(원격 추적 브랜치에서 로컬 생성). 작업트리에 `.omc/`, `CLAUDE.md` untracked만 있고 체크아웃을 막지 않음.
+
+- [ ] **Step 2: 실패 테스트 작성**
+
+Create `src/chat/chat.gateway.spec.ts`:
+```ts
+import { TokenExpiredError } from '@nestjs/jwt';
+
+import { ChatGateway } from './chat.gateway';
+import { ChatEvent } from './chat.events';
+
+describe('ChatGateway.handleConnection', () => {
+  const makeGateway = (verifyImpl: () => unknown) => {
+    const jwtService = { verify: jest.fn(verifyImpl) } as unknown as never;
+    const roomService = {} as never;
+    const fcmService = {} as never;
+    return new ChatGateway(jwtService, roomService, fcmService);
+  };
+
+  const makeClient = (token?: string) =>
+    ({
+      handshake: { query: { Authentication: token } },
+      data: {},
+      join: jest.fn().mockResolvedValue(undefined),
+      emit: jest.fn(),
+      disconnect: jest.fn(),
+    }) as never as import('socket.io').Socket;
+
+  it('인증 성공 시 connected 이벤트를 emit하고 연결을 끊지 않는다', async () => {
+    const gateway = makeGateway(() => ({ uuid: 'user-1' }));
+    const client = makeClient('valid-token');
+
+    await gateway.handleConnection(client);
+
+    expect(client.join).toHaveBeenCalledWith('user-user-1');
+    expect(client.emit).toHaveBeenCalledWith(ChatEvent.CONNECTED);
+    expect(client.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('토큰 만료 시 accessTokenExpired를 emit하고 connected는 보내지 않는다', async () => {
+    const gateway = makeGateway(() => {
+      throw new TokenExpiredError('jwt expired', new Date());
+    });
+    const client = makeClient('expired-token');
+
+    await gateway.handleConnection(client);
+
+    expect(client.emit).toHaveBeenCalledWith(
+      ChatEvent.ACCESS_TOKEN_EXPIRED,
+      expect.objectContaining({ error: 'AccessTokenExpired' }),
+    );
+    expect(client.emit).not.toHaveBeenCalledWith(ChatEvent.CONNECTED);
+    expect(client.disconnect).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 3: 테스트 실패 확인**
+
+Run: `cd ~/university_life/PoApper/paxi-popo-nest-api && npx jest src/chat/chat.gateway.spec.ts`
+Expected: FAIL — `ChatEvent.CONNECTED`가 없어 컴파일/단언 실패(`connected` emit 없음).
+
+- [ ] **Step 4: `CONNECTED` 상수 추가**
+
+`src/chat/chat.events.ts`에서 `ERROR = 'error',` 줄 바로 위(또는 방 이벤트 아래)에 연결 이벤트를 추가:
+```ts
+  // 연결 관련 이벤트
+  CONNECTED = 'connected',
+
+  // 에러 이벤트
+  ERROR = 'error',
+```
+
+- [ ] **Step 5: `handleConnection` 성공 경로에서 emit**
+
+`src/chat/chat.gateway.ts`의 성공 경로에서 `await client.join(...)` 직후에 추가:
+```ts
+      await client.join(`user-${payload.uuid}`);
+      // 인증 성공 확정 신호. 클라이언트는 전송 계층 connect가 아니라 이 이벤트로
+      // 실제 사용 가능 상태를 판단한다(만료 토큰이면 여기 도달하지 않고 끊김).
+      client.emit(ChatEvent.CONNECTED);
+```
+
+- [ ] **Step 6: 테스트 통과 확인**
+
+Run: `cd ~/university_life/PoApper/paxi-popo-nest-api && npx jest src/chat/chat.gateway.spec.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: 커밋**
+
+```bash
+cd ~/university_life/PoApper/paxi-popo-nest-api
+git add src/chat/chat.events.ts src/chat/chat.gateway.ts src/chat/chat.gateway.spec.ts
+git commit -m "feat: 웹소켓 인증 성공 시 connected 이벤트 emit"
+```
+
+---
+
+## Task 2: 클라이언트 — `connected` 이벤트로 소켓 인증 확정 처리
+
+**Files:**
+- Modify: `src/constants/socket-events.ts`
+- Modify: `src/utils/socket-factory.ts:32-35` (`socket.on('connect', ...)`)
+- Modify: `src/utils/__tests__/socket-factory.test.ts`
+
+작업 디렉터리: `~/university_life/PoApper/popo-mobile/.worktrees/ws-token-refresh`
+
+- [ ] **Step 1: 실패 테스트로 갱신**
+
+`src/utils/__tests__/socket-factory.test.ts`에서 기존
+`it('connect 이벤트에서 onSocketConnected를 호출한다', ...)` 블록을 아래 두 테스트로 교체:
+```ts
+  it('connected 이벤트에서 onSocketConnected를 호출한다', async () => {
+    const {socket, onSocketConnected} = await setup();
+
+    socket.trigger(ChatEvent.CONNECTED);
+
+    expect(onSocketConnected).toHaveBeenCalledTimes(1);
+  });
+
+  it('전송 connect 이벤트로는 onSocketConnected를 호출하지 않는다', async () => {
+    const {socket, onSocketConnected} = await setup();
+
+    socket.trigger('connect');
+
+    expect(onSocketConnected).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `npm run test -- socket-factory`
+Expected: FAIL — `ChatEvent.CONNECTED` 미정의 및 `connect` 트리거로 여전히 `onSocketConnected` 호출됨.
+
+- [ ] **Step 3: 클라이언트 상수 추가**
+
+`src/constants/socket-events.ts`에서 `// 에러 이벤트` 위에 추가:
+```ts
+  // 연결 관련 이벤트
+  // 서버 handleConnection이 토큰 검증에 성공하면 보낸다. 전송 계층 connect가
+  // 아니라 이 이벤트를 실제 사용 가능(인증 확정)으로 취급한다.
+  CONNECTED = 'connected',
+
+  // 에러 이벤트
+  ERROR = 'error',
+```
+
+- [ ] **Step 4: socket-factory 배선 변경**
+
+`src/utils/socket-factory.ts`의 아래 블록:
+```ts
+  socket.on('connect', () => {
+    console.debug('웹소켓 연결 완료');
+    onSocketConnected();
+  });
+```
+을 다음으로 교체:
+```ts
+  socket.on('connect', () => {
+    // 전송 계층 연결일 뿐 인증 확정이 아니다. 서버가 handleConnection에서 토큰을
+    // 검증한 뒤 connected 이벤트를 보내야 실제 사용 가능 상태다.
+    console.debug('웹소켓 전송 계층 연결 (인증 확정 전)');
+  });
+
+  socket.on(ChatEvent.CONNECTED, () => {
+    console.debug('웹소켓 서버 인증 완료');
+    onSocketConnected();
+  });
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `npm run test -- socket-factory`
+Expected: PASS (기존 유지 + 신규 2건 포함 전부 통과).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd ~/university_life/PoApper/popo-mobile/.worktrees/ws-token-refresh
+git add src/constants/socket-events.ts src/utils/socket-factory.ts src/utils/__tests__/socket-factory.test.ts
+git commit -m "feat: 서버 connected 이벤트로 소켓 인증 확정 처리"
+```
+
+---
+
+## Task 3: 클라이언트 — 재인증 상한 도달 시 `onGiveUp` 콜백 추가
+
+**Files:**
+- Modify: `src/utils/socket-reauth.ts` (`ReauthDeps` 타입, `maxAttempts` 분기)
+- Modify: `src/utils/__tests__/socket-reauth.test.ts`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`src/utils/__tests__/socket-reauth.test.ts`의 `makeDeps`에 `onGiveUp` 추가:
+```ts
+const makeDeps = (overrides: Partial<ReauthDeps> = {}) => ({
+  releaseSocket: jest.fn(),
+  refreshAccessToken: jest.fn().mockResolvedValue(undefined),
+  recreateSocket: jest.fn().mockResolvedValue(undefined),
+  setSocketConnected: jest.fn(),
+  onGiveUp: jest.fn(),
+  ...overrides,
+});
+```
+그리고 `describe('reconnectWithFreshToken', ...)` 안에 테스트 2건 추가:
+```ts
+  it('상한 도달로 중단할 때 onGiveUp을 호출한다', async () => {
+    const deps = makeDeps();
+    const guard = createReauthGuard();
+    guard.reauthCount = 2; // 이미 상한 도달 상태
+
+    await reconnectWithFreshToken(guard, {...deps, maxAttempts: 2});
+
+    expect(deps.onGiveUp).toHaveBeenCalledTimes(1);
+    expect(deps.recreateSocket).not.toHaveBeenCalled();
+  });
+
+  it('정상 재연결 경로에서는 onGiveUp을 호출하지 않는다', async () => {
+    const deps = makeDeps();
+    const guard = createReauthGuard();
+
+    await reconnectWithFreshToken(guard, deps);
+
+    expect(deps.onGiveUp).not.toHaveBeenCalled();
+    expect(deps.recreateSocket).toHaveBeenCalledTimes(1);
+  });
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `npm run test -- socket-reauth`
+Expected: FAIL — `onGiveUp`이 호출되지 않아 `상한 도달로 중단할 때 onGiveUp을 호출한다` 실패.
+
+- [ ] **Step 3: `ReauthDeps`에 `onGiveUp` 추가**
+
+`src/utils/socket-reauth.ts`의 `ReauthDeps` 타입에서 `maxAttempts?` 위에 추가:
+```ts
+  // 재연결 진행 동안 연결 상태 표시 갱신 (선택)
+  setSocketConnected?: (connected: boolean) => void;
+  // 재연결을 포기했을 때(상한 도달) 호출. UI에 종료 상태를 알린다. (선택)
+  onGiveUp?: () => void;
+  // 정상 연결 없이 허용할 최대 갱신 횟수 (기본 2)
+  maxAttempts?: number;
+```
+
+- [ ] **Step 4: `maxAttempts` 분기에서 `onGiveUp` 호출**
+
+`src/utils/socket-reauth.ts`의 아래 분기:
+```ts
+    if (guard.reauthCount >= maxAttempts) {
+      console.error('토큰 갱신 반복 실패 — 재연결 중단');
+      // releaseSocket은 리스너 제거 후 disconnect하므로 disconnect 이벤트가
+      // 발생하지 않는다. UI가 연결됨으로 남지 않도록 명시적으로 끊김 처리한다.
+      deps.setSocketConnected?.(false);
+      deps.releaseSocket();
+      return;
+    }
+```
+을 다음으로 교체(마지막에 `onGiveUp` 호출 추가):
+```ts
+    if (guard.reauthCount >= maxAttempts) {
+      console.error('토큰 갱신 반복 실패 — 재연결 중단');
+      // releaseSocket은 리스너 제거 후 disconnect하므로 disconnect 이벤트가
+      // 발생하지 않는다. UI가 연결됨으로 남지 않도록 명시적으로 끊김 처리하고,
+      // onGiveUp으로 종료 상태를 알린다(재입장으로만 복구).
+      deps.setSocketConnected?.(false);
+      deps.releaseSocket();
+      deps.onGiveUp?.();
+      return;
+    }
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `npm run test -- socket-reauth`
+Expected: PASS (기존 8건 + 신규 2건).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add src/utils/socket-reauth.ts src/utils/__tests__/socket-reauth.test.ts
+git commit -m "feat: 재인증 상한 도달 시 onGiveUp 콜백 추가"
+```
+
+---
+
+## Task 4: 클라이언트 — 재연결 실패 안내 및 재입장 복구 처리
+
+**Files:**
+- Modify: `src/screens/paxi/NewChatScreen.tsx`
+
+RN 화면이라 단위 테스트 없이 편집 후 수동 검증한다. 아래 5개 편집을 순서대로 적용한다.
+
+- [ ] **Step 1: `reconnectFailed` 상태 추가**
+
+`src/screens/paxi/NewChatScreen.tsx`에서
+`const [hasDisconnected, setHasDisconnected] = useState<boolean>(false);` 아래에 추가:
+```ts
+  const [hasDisconnected, setHasDisconnected] = useState<boolean>(false);
+  // 재인증 상한 도달로 재연결을 포기한 상태 (채팅방 재입장으로만 복구)
+  const [reconnectFailed, setReconnectFailed] = useState<boolean>(false);
+```
+
+- [ ] **Step 2: `onSocketConnected`에서 실패 상태 해제**
+
+`const onSocketConnected = async () => {` 본문의 `setSocketConnected(true);` 아래에 추가:
+```ts
+  const onSocketConnected = async () => {
+    setSocketConnected(true);
+    setReconnectFailed(false); // 정상 인증되면 실패 안내 해제
+    reauthGuardRef.current.reauthCount = 0; // 정상 연결되면 토큰 갱신 카운터 초기화
+```
+
+- [ ] **Step 3: `onAccessTokenExpired` deps에 `onGiveUp` 전달**
+
+`const onAccessTokenExpired = () =>` 블록을 다음으로 교체:
+```ts
+  const onAccessTokenExpired = () =>
+    reconnectWithFreshToken(reauthGuardRef.current, {
+      releaseSocket: releaseCurrentSocket,
+      refreshAccessToken,
+      recreateSocket: initSocket,
+      setSocketConnected,
+      onGiveUp: () => setReconnectFailed(true),
+    });
+```
+
+- [ ] **Step 4: `useFocusEffect`에서 가드/실패 상태 초기화**
+
+`useFocusEffect(useCallback(() => { ... }, []))`의 상단 초기화 블록을 다음으로 교체:
+```ts
+      // 포커스마다 새 소켓을 생성하므로 첫 connect를 최초 연결로 취급한다.
+      hasConnectedOnceRef.current = false;
+      // 재입장이 유일한 복구 경로이므로 재인증 가드를 새로 초기화한다.
+      // (리마운트 없이 재포커스만 되는 경우에도 새 재연결 예산을 부여)
+      reauthGuardRef.current = createReauthGuard();
+      // 이전 세션의 연결 상태가 남아 끊김/실패 배너가 오표시되거나 입력창이
+      // 잘못 활성화되지 않도록, 초기 connect 전까지 연결 UI 상태를 초기화한다.
+      setSocketConnected(false);
+      setHasDisconnected(false);
+      setReconnectFailed(false);
+```
+
+- [ ] **Step 5: 배너 메시지 계산 + 렌더 교체**
+
+`return (` 직전(예: `handleMyMsgClick` 정의 아래)에 배너 메시지 계산을 추가:
+```ts
+  const connectionBannerMessage = reconnectFailed
+    ? '채팅 연결에 실패했습니다. 채팅방에 다시 입장해 주세요'
+    : !socketConnected && hasDisconnected
+    ? '연결이 끊어졌습니다. 재연결 중…'
+    : null;
+```
+그리고 기존 배너 JSX 블록:
+```tsx
+      {!socketConnected && hasDisconnected && (
+        <View style={styles.socketConnection}>
+          <View
+            style={[
+              styles.socketConnectionInner,
+              {backgroundColor: isDarkMode ? '#333' : '#eee'},
+            ]}>
+            <Icon
+              name="link-off"
+              size={18}
+              color={isDarkMode ? '#FFFFFF' : '#000000'}
+            />
+            <Text style={{color: textColor(isDarkMode)}}>
+              연결이 끊어졌습니다. 재연결 중…
+            </Text>
+          </View>
+        </View>
+      )}
+```
+을 다음으로 교체:
+```tsx
+      {connectionBannerMessage && (
+        <View style={styles.socketConnection}>
+          <View
+            style={[
+              styles.socketConnectionInner,
+              {backgroundColor: isDarkMode ? '#333' : '#eee'},
+            ]}>
+            <Icon
+              name="link-off"
+              size={18}
+              color={isDarkMode ? '#FFFFFF' : '#000000'}
+            />
+            <Text style={{color: textColor(isDarkMode)}}>
+              {connectionBannerMessage}
+            </Text>
+          </View>
+        </View>
+      )}
+```
+
+- [ ] **Step 6: 타입체크/린트 확인**
+
+Run: `npm run test && npx tsc --noEmit`
+Expected: Jest 전체 통과, 타입 에러 없음. (`createReauthGuard`는 이미 import되어 있음.)
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add src/screens/paxi/NewChatScreen.tsx
+git commit -m "feat: 채팅 재연결 실패 안내 및 재입장 복구 처리"
+```
+
+---
+
+## Task 5: 최종 검증 (양쪽 저장소)
+
+**Files:** 없음(검증만)
+
+- [ ] **Step 1: 클라이언트 전체 테스트 + pre-commit**
+
+Run:
+```bash
+cd ~/university_life/PoApper/popo-mobile/.worktrees/ws-token-refresh
+npm run test && npm run pc
+```
+Expected: Jest 전체 통과, `npm run pc`(format + lint + checks) 통과.
+
+- [ ] **Step 2: 서버 전체 테스트**
+
+Run:
+```bash
+cd ~/university_life/PoApper/paxi-popo-nest-api
+npx jest
+```
+Expected: 전체 통과(신규 gateway spec 포함).
+
+- [ ] **Step 3: 수동 시나리오 검증 (실기기/시뮬레이터, 서버 협조)**
+
+짧은 만료 토큰으로 확인:
+1. 정상 입장 → 전송 connect 후 `connected` 수신 → 입력창 활성, 배너 없음.
+2. 토큰 만료 → `accessTokenExpired` → 갱신 → 재생성 → `connected` → 정상 복구, `reauthCount` 리셋.
+3. 갱신해도 계속 만료(상한 2회 도달) → "채팅 연결에 실패했습니다. 채팅방에 다시 입장해 주세요" 배너 표시, 입력창 비활성.
+4. 3 상태에서 채팅방 나갔다 재입장 → 가드 초기화되어 재연결 시도 재개.
+5. 갱신 자체 실패 → 기존 로그인 화면 이동 흐름 유지.
+
+---
+
+## Self-Review 결과
+
+- **Spec 커버리지:** A(서버 이벤트)=Task1, B(클라 배선)=Task2, C(onGiveUp+배너)=Task3·4, D(포커스 가드 초기화)=Task4 Step4, 테스트=Task1·2·3·Task5, 배포 순서=헤더에 명시. 누락 없음.
+- **Placeholder:** 모든 스텝에 실제 코드/명령 포함. 없음.
+- **타입 일관성:** `onGiveUp?: () => void`(Task3 정의) → Task4에서 동일 시그니처로 전달. `createReauthGuard`(기존 export)·`reconnectWithFreshToken`·`ReauthDeps` 명칭 일치. `ChatEvent.CONNECTED = 'connected'` 서버/클라 문자열 일치.

--- a/docs/superpowers/plans/2026-07-12-websocket-token-expiry-reconnect.md
+++ b/docs/superpowers/plans/2026-07-12-websocket-token-expiry-reconnect.md
@@ -9,6 +9,7 @@
 **Tech Stack:** NestJS + socket.io(서버), React Native + socket.io-client + Jest(클라이언트). 두 저장소에 걸친 변경.
 
 **저장소 / 브랜치:**
+
 - 서버: `~/university_life/PoApper/paxi-popo-nest-api`, 브랜치 `refactor/websocket-error-event`
 - 클라이언트: `~/university_life/PoApper/popo-mobile/.worktrees/ws-token-refresh`, 브랜치 `feat/websocket-token-refresh`
 
@@ -21,11 +22,13 @@
 ## File Structure
 
 **서버 (paxi-popo-nest-api):**
+
 - Modify: `src/chat/chat.events.ts` — `CONNECTED` 이벤트 상수 추가
 - Modify: `src/chat/chat.gateway.ts` — 인증 성공 시 `connected` emit
 - Create: `src/chat/chat.gateway.spec.ts` — `handleConnection` 단위 테스트
 
 **클라이언트 (popo-mobile):**
+
 - Modify: `src/constants/socket-events.ts` — `CONNECTED` 상수 추가(서버와 일치)
 - Modify: `src/utils/socket-factory.ts` — 전송 `connect`는 로그만, `connected`에 `onSocketConnected` 바인딩
 - Modify: `src/utils/__tests__/socket-factory.test.ts` — `connected` 배선 테스트로 갱신
@@ -38,6 +41,7 @@
 ## Task 1: 서버 — 인증 성공 시 `connected` 이벤트 emit
 
 **Files:**
+
 - Modify: `~/university_life/PoApper/paxi-popo-nest-api/src/chat/chat.events.ts`
 - Modify: `~/university_life/PoApper/paxi-popo-nest-api/src/chat/chat.gateway.ts` (성공 경로, `client.join` 직후)
 - Create: `~/university_life/PoApper/paxi-popo-nest-api/src/chat/chat.gateway.spec.ts`
@@ -45,23 +49,26 @@
 - [ ] **Step 1: 서버 브랜치 체크아웃**
 
 Run:
+
 ```bash
 cd ~/university_life/PoApper/paxi-popo-nest-api && git checkout refactor/websocket-error-event
 ```
+
 Expected: `refactor/websocket-error-event` 브랜치로 전환(원격 추적 브랜치에서 로컬 생성). 작업트리에 `.omc/`, `CLAUDE.md` untracked만 있고 체크아웃을 막지 않음.
 
 - [ ] **Step 2: 실패 테스트 작성**
 
 Create `src/chat/chat.gateway.spec.ts`:
-```ts
-import { TokenExpiredError } from '@nestjs/jwt';
 
-import { ChatGateway } from './chat.gateway';
-import { ChatEvent } from './chat.events';
+```ts
+import {TokenExpiredError} from '@nestjs/jwt';
+
+import {ChatGateway} from './chat.gateway';
+import {ChatEvent} from './chat.events';
 
 describe('ChatGateway.handleConnection', () => {
   const makeGateway = (verifyImpl: () => unknown) => {
-    const jwtService = { verify: jest.fn(verifyImpl) } as unknown as never;
+    const jwtService = {verify: jest.fn(verifyImpl)} as unknown as never;
     const roomService = {} as never;
     const fcmService = {} as never;
     return new ChatGateway(jwtService, roomService, fcmService);
@@ -69,15 +76,15 @@ describe('ChatGateway.handleConnection', () => {
 
   const makeClient = (token?: string) =>
     ({
-      handshake: { query: { Authentication: token } },
+      handshake: {query: {Authentication: token}},
       data: {},
       join: jest.fn().mockResolvedValue(undefined),
       emit: jest.fn(),
       disconnect: jest.fn(),
-    }) as never as import('socket.io').Socket;
+    } as never as import('socket.io').Socket);
 
   it('인증 성공 시 connected 이벤트를 emit하고 연결을 끊지 않는다', async () => {
-    const gateway = makeGateway(() => ({ uuid: 'user-1' }));
+    const gateway = makeGateway(() => ({uuid: 'user-1'}));
     const client = makeClient('valid-token');
 
     await gateway.handleConnection(client);
@@ -97,7 +104,7 @@ describe('ChatGateway.handleConnection', () => {
 
     expect(client.emit).toHaveBeenCalledWith(
       ChatEvent.ACCESS_TOKEN_EXPIRED,
-      expect.objectContaining({ error: 'AccessTokenExpired' }),
+      expect.objectContaining({error: 'AccessTokenExpired'}),
     );
     expect(client.emit).not.toHaveBeenCalledWith(ChatEvent.CONNECTED);
     expect(client.disconnect).toHaveBeenCalled();
@@ -113,6 +120,7 @@ Expected: FAIL — `ChatEvent.CONNECTED`가 없어 컴파일/단언 실패(`conn
 - [ ] **Step 4: `CONNECTED` 상수 추가**
 
 `src/chat/chat.events.ts`에서 `ERROR = 'error',` 줄 바로 위(또는 방 이벤트 아래)에 연결 이벤트를 추가:
+
 ```ts
   // 연결 관련 이벤트
   CONNECTED = 'connected',
@@ -124,11 +132,12 @@ Expected: FAIL — `ChatEvent.CONNECTED`가 없어 컴파일/단언 실패(`conn
 - [ ] **Step 5: `handleConnection` 성공 경로에서 emit**
 
 `src/chat/chat.gateway.ts`의 성공 경로에서 `await client.join(...)` 직후에 추가:
+
 ```ts
-      await client.join(`user-${payload.uuid}`);
-      // 인증 성공 확정 신호. 클라이언트는 전송 계층 connect가 아니라 이 이벤트로
-      // 실제 사용 가능 상태를 판단한다(만료 토큰이면 여기 도달하지 않고 끊김).
-      client.emit(ChatEvent.CONNECTED);
+await client.join(`user-${payload.uuid}`);
+// 인증 성공 확정 신호. 클라이언트는 전송 계층 connect가 아니라 이 이벤트로
+// 실제 사용 가능 상태를 판단한다(만료 토큰이면 여기 도달하지 않고 끊김).
+client.emit(ChatEvent.CONNECTED);
 ```
 
 - [ ] **Step 6: 테스트 통과 확인**
@@ -149,6 +158,7 @@ git commit -m "feat: 웹소켓 인증 성공 시 connected 이벤트 emit"
 ## Task 2: 클라이언트 — `connected` 이벤트로 소켓 인증 확정 처리
 
 **Files:**
+
 - Modify: `src/constants/socket-events.ts`
 - Modify: `src/utils/socket-factory.ts:32-35` (`socket.on('connect', ...)`)
 - Modify: `src/utils/__tests__/socket-factory.test.ts`
@@ -159,22 +169,23 @@ git commit -m "feat: 웹소켓 인증 성공 시 connected 이벤트 emit"
 
 `src/utils/__tests__/socket-factory.test.ts`에서 기존
 `it('connect 이벤트에서 onSocketConnected를 호출한다', ...)` 블록을 아래 두 테스트로 교체:
+
 ```ts
-  it('connected 이벤트에서 onSocketConnected를 호출한다', async () => {
-    const {socket, onSocketConnected} = await setup();
+it('connected 이벤트에서 onSocketConnected를 호출한다', async () => {
+  const {socket, onSocketConnected} = await setup();
 
-    socket.trigger(ChatEvent.CONNECTED);
+  socket.trigger(ChatEvent.CONNECTED);
 
-    expect(onSocketConnected).toHaveBeenCalledTimes(1);
-  });
+  expect(onSocketConnected).toHaveBeenCalledTimes(1);
+});
 
-  it('전송 connect 이벤트로는 onSocketConnected를 호출하지 않는다', async () => {
-    const {socket, onSocketConnected} = await setup();
+it('전송 connect 이벤트로는 onSocketConnected를 호출하지 않는다', async () => {
+  const {socket, onSocketConnected} = await setup();
 
-    socket.trigger('connect');
+  socket.trigger('connect');
 
-    expect(onSocketConnected).not.toHaveBeenCalled();
-  });
+  expect(onSocketConnected).not.toHaveBeenCalled();
+});
 ```
 
 - [ ] **Step 2: 테스트 실패 확인**
@@ -185,6 +196,7 @@ Expected: FAIL — `ChatEvent.CONNECTED` 미정의 및 `connect` 트리거로 �
 - [ ] **Step 3: 클라이언트 상수 추가**
 
 `src/constants/socket-events.ts`에서 `// 에러 이벤트` 위에 추가:
+
 ```ts
   // 연결 관련 이벤트
   // 서버 handleConnection이 토큰 검증에 성공하면 보낸다. 전송 계층 connect가
@@ -198,24 +210,27 @@ Expected: FAIL — `ChatEvent.CONNECTED` 미정의 및 `connect` 트리거로 �
 - [ ] **Step 4: socket-factory 배선 변경**
 
 `src/utils/socket-factory.ts`의 아래 블록:
-```ts
-  socket.on('connect', () => {
-    console.debug('웹소켓 연결 완료');
-    onSocketConnected();
-  });
-```
-을 다음으로 교체:
-```ts
-  socket.on('connect', () => {
-    // 전송 계층 연결일 뿐 인증 확정이 아니다. 서버가 handleConnection에서 토큰을
-    // 검증한 뒤 connected 이벤트를 보내야 실제 사용 가능 상태다.
-    console.debug('웹소켓 전송 계층 연결 (인증 확정 전)');
-  });
 
-  socket.on(ChatEvent.CONNECTED, () => {
-    console.debug('웹소켓 서버 인증 완료');
-    onSocketConnected();
-  });
+```ts
+socket.on('connect', () => {
+  console.debug('웹소켓 연결 완료');
+  onSocketConnected();
+});
+```
+
+을 다음으로 교체:
+
+```ts
+socket.on('connect', () => {
+  // 전송 계층 연결일 뿐 인증 확정이 아니다. 서버가 handleConnection에서 토큰을
+  // 검증한 뒤 connected 이벤트를 보내야 실제 사용 가능 상태다.
+  console.debug('웹소켓 전송 계층 연결 (인증 확정 전)');
+});
+
+socket.on(ChatEvent.CONNECTED, () => {
+  console.debug('웹소켓 서버 인증 완료');
+  onSocketConnected();
+});
 ```
 
 - [ ] **Step 5: 테스트 통과 확인**
@@ -236,12 +251,14 @@ git commit -m "feat: 서버 connected 이벤트로 소켓 인증 확정 처리"
 ## Task 3: 클라이언트 — 재인증 상한 도달 시 `onGiveUp` 콜백 추가
 
 **Files:**
+
 - Modify: `src/utils/socket-reauth.ts` (`ReauthDeps` 타입, `maxAttempts` 분기)
 - Modify: `src/utils/__tests__/socket-reauth.test.ts`
 
 - [ ] **Step 1: 실패 테스트 작성**
 
 `src/utils/__tests__/socket-reauth.test.ts`의 `makeDeps`에 `onGiveUp` 추가:
+
 ```ts
 const makeDeps = (overrides: Partial<ReauthDeps> = {}) => ({
   releaseSocket: jest.fn(),
@@ -252,28 +269,30 @@ const makeDeps = (overrides: Partial<ReauthDeps> = {}) => ({
   ...overrides,
 });
 ```
+
 그리고 `describe('reconnectWithFreshToken', ...)` 안에 테스트 2건 추가:
+
 ```ts
-  it('상한 도달로 중단할 때 onGiveUp을 호출한다', async () => {
-    const deps = makeDeps();
-    const guard = createReauthGuard();
-    guard.reauthCount = 2; // 이미 상한 도달 상태
+it('상한 도달로 중단할 때 onGiveUp을 호출한다', async () => {
+  const deps = makeDeps();
+  const guard = createReauthGuard();
+  guard.reauthCount = 2; // 이미 상한 도달 상태
 
-    await reconnectWithFreshToken(guard, {...deps, maxAttempts: 2});
+  await reconnectWithFreshToken(guard, {...deps, maxAttempts: 2});
 
-    expect(deps.onGiveUp).toHaveBeenCalledTimes(1);
-    expect(deps.recreateSocket).not.toHaveBeenCalled();
-  });
+  expect(deps.onGiveUp).toHaveBeenCalledTimes(1);
+  expect(deps.recreateSocket).not.toHaveBeenCalled();
+});
 
-  it('정상 재연결 경로에서는 onGiveUp을 호출하지 않는다', async () => {
-    const deps = makeDeps();
-    const guard = createReauthGuard();
+it('정상 재연결 경로에서는 onGiveUp을 호출하지 않는다', async () => {
+  const deps = makeDeps();
+  const guard = createReauthGuard();
 
-    await reconnectWithFreshToken(guard, deps);
+  await reconnectWithFreshToken(guard, deps);
 
-    expect(deps.onGiveUp).not.toHaveBeenCalled();
-    expect(deps.recreateSocket).toHaveBeenCalledTimes(1);
-  });
+  expect(deps.onGiveUp).not.toHaveBeenCalled();
+  expect(deps.recreateSocket).toHaveBeenCalledTimes(1);
+});
 ```
 
 - [ ] **Step 2: 테스트 실패 확인**
@@ -284,6 +303,7 @@ Expected: FAIL — `onGiveUp`이 호출되지 않아 `상한 도달로 중단할
 - [ ] **Step 3: `ReauthDeps`에 `onGiveUp` 추가**
 
 `src/utils/socket-reauth.ts`의 `ReauthDeps` 타입에서 `maxAttempts?` 위에 추가:
+
 ```ts
   // 재연결 진행 동안 연결 상태 표시 갱신 (선택)
   setSocketConnected?: (connected: boolean) => void;
@@ -296,28 +316,31 @@ Expected: FAIL — `onGiveUp`이 호출되지 않아 `상한 도달로 중단할
 - [ ] **Step 4: `maxAttempts` 분기에서 `onGiveUp` 호출**
 
 `src/utils/socket-reauth.ts`의 아래 분기:
+
 ```ts
-    if (guard.reauthCount >= maxAttempts) {
-      console.error('토큰 갱신 반복 실패 — 재연결 중단');
-      // releaseSocket은 리스너 제거 후 disconnect하므로 disconnect 이벤트가
-      // 발생하지 않는다. UI가 연결됨으로 남지 않도록 명시적으로 끊김 처리한다.
-      deps.setSocketConnected?.(false);
-      deps.releaseSocket();
-      return;
-    }
+if (guard.reauthCount >= maxAttempts) {
+  console.error('토큰 갱신 반복 실패 — 재연결 중단');
+  // releaseSocket은 리스너 제거 후 disconnect하므로 disconnect 이벤트가
+  // 발생하지 않는다. UI가 연결됨으로 남지 않도록 명시적으로 끊김 처리한다.
+  deps.setSocketConnected?.(false);
+  deps.releaseSocket();
+  return;
+}
 ```
+
 을 다음으로 교체(마지막에 `onGiveUp` 호출 추가):
+
 ```ts
-    if (guard.reauthCount >= maxAttempts) {
-      console.error('토큰 갱신 반복 실패 — 재연결 중단');
-      // releaseSocket은 리스너 제거 후 disconnect하므로 disconnect 이벤트가
-      // 발생하지 않는다. UI가 연결됨으로 남지 않도록 명시적으로 끊김 처리하고,
-      // onGiveUp으로 종료 상태를 알린다(재입장으로만 복구).
-      deps.setSocketConnected?.(false);
-      deps.releaseSocket();
-      deps.onGiveUp?.();
-      return;
-    }
+if (guard.reauthCount >= maxAttempts) {
+  console.error('토큰 갱신 반복 실패 — 재연결 중단');
+  // releaseSocket은 리스너 제거 후 disconnect하므로 disconnect 이벤트가
+  // 발생하지 않는다. UI가 연결됨으로 남지 않도록 명시적으로 끊김 처리하고,
+  // onGiveUp으로 종료 상태를 알린다(재입장으로만 복구).
+  deps.setSocketConnected?.(false);
+  deps.releaseSocket();
+  deps.onGiveUp?.();
+  return;
+}
 ```
 
 - [ ] **Step 5: 테스트 통과 확인**
@@ -337,6 +360,7 @@ git commit -m "feat: 재인증 상한 도달 시 onGiveUp 콜백 추가"
 ## Task 4: 클라이언트 — 재연결 실패 안내 및 재입장 복구 처리
 
 **Files:**
+
 - Modify: `src/screens/paxi/NewChatScreen.tsx`
 
 RN 화면이라 단위 테스트 없이 편집 후 수동 검증한다. 아래 5개 편집을 순서대로 적용한다.
@@ -345,15 +369,17 @@ RN 화면이라 단위 테스트 없이 편집 후 수동 검증한다. 아래 5
 
 `src/screens/paxi/NewChatScreen.tsx`에서
 `const [hasDisconnected, setHasDisconnected] = useState<boolean>(false);` 아래에 추가:
+
 ```ts
-  const [hasDisconnected, setHasDisconnected] = useState<boolean>(false);
-  // 재인증 상한 도달로 재연결을 포기한 상태 (채팅방 재입장으로만 복구)
-  const [reconnectFailed, setReconnectFailed] = useState<boolean>(false);
+const [hasDisconnected, setHasDisconnected] = useState<boolean>(false);
+// 재인증 상한 도달로 재연결을 포기한 상태 (채팅방 재입장으로만 복구)
+const [reconnectFailed, setReconnectFailed] = useState<boolean>(false);
 ```
 
 - [ ] **Step 2: `onSocketConnected`에서 실패 상태 해제**
 
 `const onSocketConnected = async () => {` 본문의 `setSocketConnected(true);` 아래에 추가:
+
 ```ts
   const onSocketConnected = async () => {
     setSocketConnected(true);
@@ -364,84 +390,95 @@ RN 화면이라 단위 테스트 없이 편집 후 수동 검증한다. 아래 5
 - [ ] **Step 3: `onAccessTokenExpired` deps에 `onGiveUp` 전달**
 
 `const onAccessTokenExpired = () =>` 블록을 다음으로 교체:
+
 ```ts
-  const onAccessTokenExpired = () =>
-    reconnectWithFreshToken(reauthGuardRef.current, {
-      releaseSocket: releaseCurrentSocket,
-      refreshAccessToken,
-      recreateSocket: initSocket,
-      setSocketConnected,
-      onGiveUp: () => setReconnectFailed(true),
-    });
+const onAccessTokenExpired = () =>
+  reconnectWithFreshToken(reauthGuardRef.current, {
+    releaseSocket: releaseCurrentSocket,
+    refreshAccessToken,
+    recreateSocket: initSocket,
+    setSocketConnected,
+    onGiveUp: () => setReconnectFailed(true),
+  });
 ```
 
 - [ ] **Step 4: `useFocusEffect`에서 가드/실패 상태 초기화**
 
 `useFocusEffect(useCallback(() => { ... }, []))`의 상단 초기화 블록을 다음으로 교체:
+
 ```ts
-      // 포커스마다 새 소켓을 생성하므로 첫 connect를 최초 연결로 취급한다.
-      hasConnectedOnceRef.current = false;
-      // 재입장이 유일한 복구 경로이므로 재인증 가드를 새로 초기화한다.
-      // (리마운트 없이 재포커스만 되는 경우에도 새 재연결 예산을 부여)
-      reauthGuardRef.current = createReauthGuard();
-      // 이전 세션의 연결 상태가 남아 끊김/실패 배너가 오표시되거나 입력창이
-      // 잘못 활성화되지 않도록, 초기 connect 전까지 연결 UI 상태를 초기화한다.
-      setSocketConnected(false);
-      setHasDisconnected(false);
-      setReconnectFailed(false);
+// 포커스마다 새 소켓을 생성하므로 첫 connect를 최초 연결로 취급한다.
+hasConnectedOnceRef.current = false;
+// 재입장이 유일한 복구 경로이므로 재인증 가드를 새로 초기화한다.
+// (리마운트 없이 재포커스만 되는 경우에도 새 재연결 예산을 부여)
+reauthGuardRef.current = createReauthGuard();
+// 이전 세션의 연결 상태가 남아 끊김/실패 배너가 오표시되거나 입력창이
+// 잘못 활성화되지 않도록, 초기 connect 전까지 연결 UI 상태를 초기화한다.
+setSocketConnected(false);
+setHasDisconnected(false);
+setReconnectFailed(false);
 ```
 
 - [ ] **Step 5: 배너 메시지 계산 + 렌더 교체**
 
 `return (` 직전(예: `handleMyMsgClick` 정의 아래)에 배너 메시지 계산을 추가:
+
 ```ts
-  const connectionBannerMessage = reconnectFailed
-    ? '채팅 연결에 실패했습니다. 채팅방에 다시 입장해 주세요'
-    : !socketConnected && hasDisconnected
-    ? '연결이 끊어졌습니다. 재연결 중…'
-    : null;
+const connectionBannerMessage = reconnectFailed
+  ? '채팅 연결에 실패했습니다. 채팅방에 다시 입장해 주세요'
+  : !socketConnected && hasDisconnected
+  ? '연결이 끊어졌습니다. 재연결 중…'
+  : null;
 ```
+
 그리고 기존 배너 JSX 블록:
+
 ```tsx
-      {!socketConnected && hasDisconnected && (
-        <View style={styles.socketConnection}>
-          <View
-            style={[
-              styles.socketConnectionInner,
-              {backgroundColor: isDarkMode ? '#333' : '#eee'},
-            ]}>
-            <Icon
-              name="link-off"
-              size={18}
-              color={isDarkMode ? '#FFFFFF' : '#000000'}
-            />
-            <Text style={{color: textColor(isDarkMode)}}>
-              연결이 끊어졌습니다. 재연결 중…
-            </Text>
-          </View>
-        </View>
-      )}
+{
+  !socketConnected && hasDisconnected && (
+    <View style={styles.socketConnection}>
+      <View
+        style={[
+          styles.socketConnectionInner,
+          {backgroundColor: isDarkMode ? '#333' : '#eee'},
+        ]}>
+        <Icon
+          name="link-off"
+          size={18}
+          color={isDarkMode ? '#FFFFFF' : '#000000'}
+        />
+        <Text style={{color: textColor(isDarkMode)}}>
+          연결이 끊어졌습니다. 재연결 중…
+        </Text>
+      </View>
+    </View>
+  );
+}
 ```
+
 을 다음으로 교체:
+
 ```tsx
-      {connectionBannerMessage && (
-        <View style={styles.socketConnection}>
-          <View
-            style={[
-              styles.socketConnectionInner,
-              {backgroundColor: isDarkMode ? '#333' : '#eee'},
-            ]}>
-            <Icon
-              name="link-off"
-              size={18}
-              color={isDarkMode ? '#FFFFFF' : '#000000'}
-            />
-            <Text style={{color: textColor(isDarkMode)}}>
-              {connectionBannerMessage}
-            </Text>
-          </View>
-        </View>
-      )}
+{
+  connectionBannerMessage && (
+    <View style={styles.socketConnection}>
+      <View
+        style={[
+          styles.socketConnectionInner,
+          {backgroundColor: isDarkMode ? '#333' : '#eee'},
+        ]}>
+        <Icon
+          name="link-off"
+          size={18}
+          color={isDarkMode ? '#FFFFFF' : '#000000'}
+        />
+        <Text style={{color: textColor(isDarkMode)}}>
+          {connectionBannerMessage}
+        </Text>
+      </View>
+    </View>
+  );
+}
 ```
 
 - [ ] **Step 6: 타입체크/린트 확인**
@@ -465,24 +502,29 @@ git commit -m "feat: 채팅 재연결 실패 안내 및 재입장 복구 처리"
 - [ ] **Step 1: 클라이언트 전체 테스트 + pre-commit**
 
 Run:
+
 ```bash
 cd ~/university_life/PoApper/popo-mobile/.worktrees/ws-token-refresh
 npm run test && npm run pc
 ```
+
 Expected: Jest 전체 통과, `npm run pc`(format + lint + checks) 통과.
 
 - [ ] **Step 2: 서버 전체 테스트**
 
 Run:
+
 ```bash
 cd ~/university_life/PoApper/paxi-popo-nest-api
 npx jest
 ```
+
 Expected: 전체 통과(신규 gateway spec 포함).
 
 - [ ] **Step 3: 수동 시나리오 검증 (실기기/시뮬레이터, 서버 협조)**
 
 짧은 만료 토큰으로 확인:
+
 1. 정상 입장 → 전송 connect 후 `connected` 수신 → 입력창 활성, 배너 없음.
 2. 토큰 만료 → `accessTokenExpired` → 갱신 → 재생성 → `connected` → 정상 복구, `reauthCount` 리셋.
 3. 갱신해도 계속 만료(상한 2회 도달) → "채팅 연결에 실패했습니다. 채팅방에 다시 입장해 주세요" 배너 표시, 입력창 비활성.

--- a/docs/superpowers/specs/2026-07-12-websocket-token-expiry-reconnect-design.md
+++ b/docs/superpowers/specs/2026-07-12-websocket-token-expiry-reconnect-design.md
@@ -53,8 +53,7 @@ lifecycle 훅이다(핸드셰이크 미들웨어가 아님). 따라서:
   (`'connected'`는 socket.io 예약어가 아니다 — 예약어는
   `connect`/`disconnect`/`connect_error` — 충돌 없음.)
 - `src/chat/chat.gateway.ts` `handleConnection`: 성공 경로에서
-  `await client.join(\`user-${payload.uuid}\`)` **직후**
-  `client.emit(ChatEvent.CONNECTED)`를 emit.
+  `await client.join(\`user-${payload.uuid}\`)`**직후**`client.emit(ChatEvent.CONNECTED)`를 emit.
 - 실패 경로(`accessTokenExpired` / `error` + `disconnect`)는 변경 없음.
 
 ### B. 클라이언트 배선 (popo-mobile)
@@ -74,6 +73,7 @@ lifecycle 훅이다(핸드셰이크 미들웨어가 아님). 따라서:
 
   `socketFactory` 시그니처는 그대로. 어떤 소켓 이벤트가 콜백을 호출하는지만
   바뀐다.
+
 - `NewChatScreen.onSocketConnected`의 기존 부수효과
   (`setSocketConnected(true)` / `reauthCount = 0` 리셋 / 재조회 /
   `POST /room/join`)는 유지된다(추가되는 `setReconnectFailed(false)`는 C 참조).
@@ -91,6 +91,7 @@ lifecycle 훅이다(핸드셰이크 미들웨어가 아님). 따라서:
   - `reconnectWithFreshToken(...)` deps에 `onGiveUp: () => setReconnectFailed(true)` 전달.
   - `onSocketConnected`에서 `setReconnectFailed(false)`(복구 시).
 - 배너 상태(기존 `!socketConnected && reconnectAttempt !== 0` 대체):
+
   1. **연결됨** — `socketConnected` → 배너 없음, 입력창 활성.
   2. **재연결 중** — `!socketConnected && hasDisconnected && !reconnectFailed`
      → "연결이 끊어졌습니다. 재연결 중…".
@@ -110,7 +111,7 @@ lifecycle 훅이다(핸드셰이크 미들웨어가 아님). 따라서:
   - `reauthGuardRef.current = createReauthGuard()` (또는
     `reauthCount = 0`, `isReauthing = false`),
   - `setReconnectFailed(false)`
-  를 초기화한다.
+    를 초기화한다.
 
 이것이 없으면 리마운트 없이 재포커스만 되는 경우 `reauthCount`가 상한에 남아
 첫 만료에서 즉시 다시 포기한다. 이 초기화로 재입장이 리마운트든 재포커스든
@@ -118,11 +119,11 @@ lifecycle 훅이다(핸드셰이크 미들웨어가 아님). 따라서:
 
 ## 상태 모델 요약
 
-| 상태 | 조건 | 입력창 | 배너 |
-| --- | --- | --- | --- |
-| 연결됨 | `socketConnected` | 활성 | 없음 |
-| 재연결 중 | `!socketConnected && hasDisconnected && !reconnectFailed` | 비활성 | "연결이 끊어졌습니다. 재연결 중…" |
-| 실패 | `reconnectFailed` | 비활성 | "채팅 연결에 실패했습니다. 채팅방에 다시 입장해 주세요" |
+| 상태      | 조건                                                      | 입력창 | 배너                                                    |
+| --------- | --------------------------------------------------------- | ------ | ------------------------------------------------------- |
+| 연결됨    | `socketConnected`                                         | 활성   | 없음                                                    |
+| 재연결 중 | `!socketConnected && hasDisconnected && !reconnectFailed` | 비활성 | "연결이 끊어졌습니다. 재연결 중…"                       |
+| 실패      | `reconnectFailed`                                         | 비활성 | "채팅 연결에 실패했습니다. 채팅방에 다시 입장해 주세요" |
 
 ## 정상/이상 흐름
 

--- a/docs/superpowers/specs/2026-07-12-websocket-token-expiry-reconnect-design.md
+++ b/docs/superpowers/specs/2026-07-12-websocket-token-expiry-reconnect-design.md
@@ -1,0 +1,153 @@
+# WebSocket 토큰 만료 재연결 — 인증 확정 신호 + 재연결 실패 안내
+
+- 날짜: 2026-07-12
+- 관련 PR: popo-mobile#293 (`feat/websocket-token-refresh`), paxi-popo-nest-api#154 (`refactor/websocket-error-event`)
+- 상태: 설계 승인됨
+
+## 배경
+
+Paxi 채팅방(`NewChatScreen`) 소켓은 토큰 만료 시 리프레시 토큰으로
+갱신 후 소켓을 재생성해 복구한다(PR #293). 코드 리뷰에서 이 복구 로직의
+무한 루프 방어 가드가 실제로는 무력화된다는 사실이 확인되었다.
+
+### 근본 원인
+
+서버 `ChatGateway.handleConnection`은 **소켓 연결이 성립된 뒤** 실행되는
+lifecycle 훅이다(핸드셰이크 미들웨어가 아님). 따라서:
+
+1. 클라이언트 전송 계층 `'connect'` 이벤트가 **먼저** 발생한다.
+2. 그 다음 서버가 토큰을 검증하고, 만료면 `accessTokenExpired`를 emit한 뒤
+   `client.disconnect()`로 끊는다.
+
+클라이언트 `onSocketConnected`(전송 `'connect'`에 바인딩)는
+`reauthGuardRef.current.reauthCount = 0`으로 재인증 카운터를 리셋한다.
+`'connect'`가 매 사이클 `accessTokenExpired`보다 먼저 발생하므로, 카운터는
+매번 0으로 리셋되어 `maxAttempts`(기본 2)에 도달하지 못한다. 갱신된 토큰을
+서버가 계속 거부하면(서버 시계 오차, 갱신이 유효 토큰을 반환하지 못하는 경우)
+클라이언트는 `/auth/refresh` + 소켓 재생성을 **무한 반복**한다.
+
+또한 가드가 상한에 도달하는 상황(원인 해결 후)에서는 재연결을 포기하지만,
+`releaseSocket`이 리스너 제거 후 `disconnect`하므로 `onSocketDisconnected`가
+발생하지 않아, 안내 배너가 뜨지 않고 입력창만 비활성으로 남는 사각지대가 있다.
+
+## 목표
+
+1. 전송 계층 연결과 **서버 인증 확정**을 구분해, 재인증 카운터가 실제로
+   인증된 세션에서만 리셋되도록 한다(무한 루프 가드 복구).
+2. 재연결을 포기했을 때(가드 상한 도달) 사용자에게 명확한 종료 상태를 안내한다.
+
+## 비목표
+
+- 배너의 레이아웃 배치(절대 위치 vs 레이아웃 흐름)는 재검토하지 않는다.
+  PR #293이 흐름 배치로 바꾼 근거(노치/헤더 높이에서 `top:60` 어긋남)는
+  타당하므로 유지하고, 실패 상태 문구만 기존 배너에 추가한다.
+- 토큰 query string 제거(HANDOFF #5 보안 항목)는 이번 범위 밖.
+
+## 설계
+
+### A. 프로토콜 / 서버 (paxi-popo-nest-api, `refactor/websocket-error-event`)
+
+인증 성공을 알리는 긍정 이벤트를 추가한다.
+
+- `src/chat/chat.events.ts`: `ChatEvent` enum에 `CONNECTED = 'connected'` 추가.
+  (`'connected'`는 socket.io 예약어가 아니다 — 예약어는
+  `connect`/`disconnect`/`connect_error` — 충돌 없음.)
+- `src/chat/chat.gateway.ts` `handleConnection`: 성공 경로에서
+  `await client.join(\`user-${payload.uuid}\`)` **직후**
+  `client.emit(ChatEvent.CONNECTED)`를 emit.
+- 실패 경로(`accessTokenExpired` / `error` + `disconnect`)는 변경 없음.
+
+### B. 클라이언트 배선 (popo-mobile)
+
+- `src/constants/socket-events.ts`: `CONNECTED = 'connected'` 추가
+  (서버 문자열과 정확히 일치해야 함).
+- `src/utils/socket-factory.ts`: 전송 `'connect'`는 디버그 로그만 남기고,
+  `onSocketConnected`는 서버 `connected` 이벤트에 바인딩한다.
+
+  ```ts
+  socket.on('connect', () => console.debug('전송 계층 연결 (인증 확정 전)'));
+  socket.on(ChatEvent.CONNECTED, () => {
+    console.debug('서버 인증 완료');
+    onSocketConnected();
+  });
+  ```
+
+  `socketFactory` 시그니처는 그대로. 어떤 소켓 이벤트가 콜백을 호출하는지만
+  바뀐다.
+- `NewChatScreen.onSocketConnected`의 기존 부수효과
+  (`setSocketConnected(true)` / `reauthCount = 0` 리셋 / 재조회 /
+  `POST /room/join`)는 유지된다(추가되는 `setReconnectFailed(false)`는 C 참조).
+  다만 이제 서버 인증 확정 후에만 호출되므로 이 부수효과들이 곧 끊길 연결에서는
+  실행되지 않는다. 핵심 수정은 **`reauthCount = 0` 리셋이 실제 인증된 세션에서만
+  발생**한다는 점이며, 이로써 `maxAttempts` 가드가 복구된다.
+
+### C. 재연결 실패 안내 (문구만, 버튼 없음)
+
+- `src/utils/socket-reauth.ts`: `ReauthDeps`에 `onGiveUp?: () => void` 추가.
+  `reauthCount >= maxAttempts` 분기에서 기존 `setSocketConnected?.(false)` +
+  `releaseSocket()`와 함께 `deps.onGiveUp?.()` 호출.
+- `NewChatScreen`:
+  - `const [reconnectFailed, setReconnectFailed] = useState(false)` 추가.
+  - `reconnectWithFreshToken(...)` deps에 `onGiveUp: () => setReconnectFailed(true)` 전달.
+  - `onSocketConnected`에서 `setReconnectFailed(false)`(복구 시).
+- 배너 상태(기존 `!socketConnected && reconnectAttempt !== 0` 대체):
+  1. **연결됨** — `socketConnected` → 배너 없음, 입력창 활성.
+  2. **재연결 중** — `!socketConnected && hasDisconnected && !reconnectFailed`
+     → "연결이 끊어졌습니다. 재연결 중…".
+  3. **실패** — `reconnectFailed`
+     → "채팅 연결에 실패했습니다. 채팅방에 다시 입장해 주세요" (문구만).
+
+  `onGiveUp`이 `reconnectFailed` 플래그를 직접 세우므로, `hasDisconnected`가
+  세워지지 않은 사각지대에서도 종료 배너가 확실히 표시된다.
+
+### D. 재입장 복구 (필수 추가)
+
+재연결 실패 후 복구 경로는 "채팅방 재입장"이 유일하다. `useFocusEffect`가
+포커스마다 재인증 가드를 초기화해야 재입장이 실제로 복구로 이어진다.
+
+- `useFocusEffect` 콜백에서 기존
+  `setSocketConnected(false)` / `setHasDisconnected(false)` 리셋과 함께:
+  - `reauthGuardRef.current = createReauthGuard()` (또는
+    `reauthCount = 0`, `isReauthing = false`),
+  - `setReconnectFailed(false)`
+  를 초기화한다.
+
+이것이 없으면 리마운트 없이 재포커스만 되는 경우 `reauthCount`가 상한에 남아
+첫 만료에서 즉시 다시 포기한다. 이 초기화로 재입장이 리마운트든 재포커스든
+새 재연결 예산을 부여한다.
+
+## 상태 모델 요약
+
+| 상태 | 조건 | 입력창 | 배너 |
+| --- | --- | --- | --- |
+| 연결됨 | `socketConnected` | 활성 | 없음 |
+| 재연결 중 | `!socketConnected && hasDisconnected && !reconnectFailed` | 비활성 | "연결이 끊어졌습니다. 재연결 중…" |
+| 실패 | `reconnectFailed` | 비활성 | "채팅 연결에 실패했습니다. 채팅방에 다시 입장해 주세요" |
+
+## 정상/이상 흐름
+
+- **정상 연결**: 전송 connect(디버그) → 서버 `connected` → `onSocketConnected`
+  (연결 표시/조인/필요 시 재조회, `reauthCount = 0`).
+- **토큰 만료 복구**: 전송 connect → 서버 `accessTokenExpired` →
+  `reconnectWithFreshToken`(release → refresh → recreate) → 새 소켓 →
+  서버 `connected` → `reauthCount = 0`. 정상 세션에서만 카운터 리셋.
+- **반복 실패**: 인증 확정 없이 만료가 반복되면 `reauthCount`가 리셋되지 않고
+  누적 → `maxAttempts` 도달 → `onGiveUp` → 실패 배너. 재입장으로만 복구.
+- **갱신 실패**: `refreshAccessToken` 내부에서 `reset_auth` + 로그인 화면 이동
+  (기존 동작 유지).
+
+## 테스트
+
+- `socket-reauth.test.ts`: `onGiveUp`이 상한 도달 시에만 호출되고 정상 경로에서는
+  호출되지 않음을 검증하는 케이스 추가. 기존 8건 유지.
+- `socket-factory.test.ts`: `connected` 이벤트에서 `onSocketConnected`가
+  호출되고 전송 `'connect'`에서는 호출되지 않음을 검증하도록 갱신.
+- 서버: `handleConnection` 성공 시 `connected` emit 검증(가능한 범위 내).
+- 전체 `jest`, `npm run pc` 통과.
+
+## 리스크 / 배포 순서
+
+- 클라이언트가 서버의 `connected` emit에 의존한다. 클라이언트가 서버보다 먼저
+  배포되면 `socketConnected`가 영영 true가 되지 않아 입력창이 비활성으로 남는다.
+  두 PR은 **세트로 머지**되어야 하며(원 PR #293 명시), 서버 배포가 선행되거나
+  동시여야 한다. 이 순서 제약을 릴리즈 시 반드시 확인한다.

--- a/src/constants/socket-events.ts
+++ b/src/constants/socket-events.ts
@@ -20,6 +20,11 @@ export const enum ChatEvent {
   // 유저 강퇴 관련 이벤트
   USER_KICKED = 'userKicked',
 
+  // 연결 관련 이벤트
+  // 서버 handleConnection이 토큰 검증에 성공하면 보낸다. 전송 계층 connect가
+  // 아니라 이 이벤트를 실제 사용 가능(인증 확정)으로 취급한다.
+  CONNECTED = 'connected',
+
   // 에러 이벤트
   ERROR = 'error',
   // 웹소켓 연결 시 액세스 토큰이 만료된 경우 서버가 내려보낸다.

--- a/src/constants/socket-events.ts
+++ b/src/constants/socket-events.ts
@@ -22,6 +22,7 @@ export const enum ChatEvent {
 
   // 에러 이벤트
   ERROR = 'error',
-  // TODO: 정말 확률이 적긴 한데, 일반적 상황이 아니라 웹소켓 연결 시 토큰 만료되었을 때 리프레시 토큰 이용해 갱신 후 웹소켓 재연결 필요
+  // 웹소켓 연결 시 액세스 토큰이 만료된 경우 서버가 내려보낸다.
+  // NewChatScreen.onAccessTokenExpired에서 리프레시 토큰으로 갱신 후 소켓을 재생성한다.
   ACCESS_TOKEN_EXPIRED = 'accessTokenExpired',
 }

--- a/src/screens/paxi/NewChatScreen.tsx
+++ b/src/screens/paxi/NewChatScreen.tsx
@@ -63,7 +63,8 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
   const reauthGuardRef = useRef<ReauthGuard>(createReauthGuard());
   // 최초 연결과 재연결을 구분 (최초 연결은 useFocusEffect 초기 조회와 중복되므로 재조회 생략)
   const hasConnectedOnceRef = useRef<boolean>(false);
-  const [reconnectAttempt, setReconnectAttempt] = useState<number>(0);
+  // 한 번이라도 끊긴 적이 있는지 (최초 연결 중에는 끊김 안내를 띄우지 않기 위함)
+  const [hasDisconnected, setHasDisconnected] = useState<boolean>(false);
   const [socketConnected, setSocketConnected] = useState<boolean>(false);
 
   const [settlementData, setSettlementData] = useState<SettlementInfoData>(
@@ -156,7 +157,6 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
 
   const onSocketConnected = async () => {
     setSocketConnected(true);
-    setReconnectAttempt(0);
     reauthGuardRef.current.reauthCount = 0; // 정상 연결되면 토큰 갱신 카운터 초기화
 
     // 재연결 시 끊긴 동안 놓친 데이터를 재조회한다. 최초 연결은
@@ -174,7 +174,7 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
 
   const onSocketDisconnected = () => {
     setSocketConnected(false);
-    setReconnectAttempt(prevNum => prevNum + 1);
+    setHasDisconnected(true);
   };
 
   // 웹소켓 연결 시 액세스 토큰이 만료된 경우: 리프레시 토큰으로 갱신한 뒤
@@ -377,7 +377,7 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
         </TouchableOpacity>
       </View>
 
-      {!socketConnected && reconnectAttempt !== 0 && (
+      {!socketConnected && hasDisconnected && (
         <View style={styles.socketConnection}>
           <View
             style={[
@@ -390,7 +390,7 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
               color={isDarkMode ? '#FFFFFF' : '#000000'}
             />
             <Text style={{color: textColor(isDarkMode)}}>
-              서버와 접속이 끊어졌습니다. 재연결 시도 {reconnectAttempt}회
+              연결이 끊어졌습니다. 재연결 중…
             </Text>
           </View>
         </View>

--- a/src/screens/paxi/NewChatScreen.tsx
+++ b/src/screens/paxi/NewChatScreen.tsx
@@ -28,6 +28,7 @@ import {RootStackParamList} from '@navigation/types';
 import paxi_api from '@utils/paxi_api';
 import {textColor, borderColor, backgroundColor, common} from '@styles/default';
 import {socketFactory} from '@utils/socket-factory';
+import {refreshAccessToken} from '@utils/refresh.utils';
 import ChatMessage from '@components/chat/ChatMessage';
 import SidebarModal from '@components/chat/SidebarModal';
 import SettlementInfoBox from '@components/chat/SettlementInfoBox';
@@ -53,6 +54,9 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
   const [chatList, setChatList] = useState<MessageData[]>([]);
   const [newChat, setNewChat] = useState<string>('');
   const socketRef = useRef<Socket | null>(null);
+  // 토큰 만료 → 갱신 → 재연결 사이클의 중복 진입/무한 루프 방지용
+  const isReauthingRef = useRef<boolean>(false);
+  const reauthCountRef = useRef<number>(0);
   const [reconnectAttempt, setReconnectAttempt] = useState<number>(0);
   const [socketConnected, setSocketConnected] = useState<boolean>(false);
 
@@ -147,6 +151,7 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
   const onSocketConnected = async () => {
     setSocketConnected(true);
     setReconnectAttempt(0);
+    reauthCountRef.current = 0; // 정상 연결되면 토큰 갱신 카운터 초기화
     paxi_api.post(`/room/join/${roomUuid}`);
   };
 
@@ -155,11 +160,44 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
     setReconnectAttempt(prevNum => prevNum + 1);
   };
 
+  // 웹소켓 연결 시 액세스 토큰이 만료된 경우: 리프레시 토큰으로 갱신한 뒤
+  // 새 토큰으로 소켓을 재생성한다. 서버가 client.disconnect()로 끊으므로
+  // socket.io 자동 재연결은 일어나지 않고, 이 핸들러가 유일한 복구 경로다.
+  const onAccessTokenExpired = async () => {
+    if (isReauthingRef.current) {
+      return; // 이벤트 중복 수신 시 1회만 갱신
+    }
+    isReauthingRef.current = true;
+
+    // 갱신 직후 다시 만료가 반복되면(서버 시계 오차 등) 무한 루프를 끊는다.
+    if (reauthCountRef.current >= 2) {
+      console.error('토큰 갱신 반복 실패 — 재연결 중단');
+      releaseCurrentSocket();
+      isReauthingRef.current = false;
+      return;
+    }
+    reauthCountRef.current += 1;
+
+    try {
+      setSocketConnected(false);
+      releaseCurrentSocket(); // stale 토큰 소켓 정리
+      await refreshAccessToken(); // 새 access/refresh 토큰 발급 + 저장
+      await initSocket(); // 새 토큰으로 소켓 재생성
+    } catch (err) {
+      // refreshAccessToken 내부에서 reset_auth + 로그인 화면 이동까지 처리됨
+      console.error('토큰 갱신 실패, 재연결 중단:', err);
+      releaseCurrentSocket();
+    } finally {
+      isReauthingRef.current = false;
+    }
+  };
+
   const initSocket = async () => {
     console.debug('새 웹소켓 생성 중...');
     const newSocket = await socketFactory(
       onSocketConnected,
       onSocketDisconnected,
+      onAccessTokenExpired,
     );
 
     newSocket.on(ChatEvent.NEW_MESSAGE, data => {

--- a/src/screens/paxi/NewChatScreen.tsx
+++ b/src/screens/paxi/NewChatScreen.tsx
@@ -65,6 +65,8 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
   const hasConnectedOnceRef = useRef<boolean>(false);
   // 한 번이라도 끊긴 적이 있는지 (최초 연결 중에는 끊김 안내를 띄우지 않기 위함)
   const [hasDisconnected, setHasDisconnected] = useState<boolean>(false);
+  // 재인증 상한 도달로 재연결을 포기한 상태 (채팅방 재입장으로만 복구)
+  const [reconnectFailed, setReconnectFailed] = useState<boolean>(false);
   const [socketConnected, setSocketConnected] = useState<boolean>(false);
 
   const [settlementData, setSettlementData] = useState<SettlementInfoData>(
@@ -157,6 +159,7 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
 
   const onSocketConnected = async () => {
     setSocketConnected(true);
+    setReconnectFailed(false); // 정상 인증되면 실패 안내 해제
     reauthGuardRef.current.reauthCount = 0; // 정상 연결되면 토큰 갱신 카운터 초기화
 
     // 재연결 시 끊긴 동안 놓친 데이터를 재조회한다. 최초 연결은
@@ -187,6 +190,7 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
       refreshAccessToken,
       recreateSocket: initSocket,
       setSocketConnected,
+      onGiveUp: () => setReconnectFailed(true),
     });
 
   const initSocket = async () => {
@@ -275,10 +279,14 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
     useCallback(() => {
       // 포커스마다 새 소켓을 생성하므로 첫 connect를 최초 연결로 취급한다.
       hasConnectedOnceRef.current = false;
-      // 이전 세션의 연결 상태가 남아 끊김 배너가 오표시되거나 입력창이
+      // 재입장이 유일한 복구 경로이므로 재인증 가드를 새로 초기화한다.
+      // (리마운트 없이 재포커스만 되는 경우에도 새 재연결 예산을 부여)
+      reauthGuardRef.current = createReauthGuard();
+      // 이전 세션의 연결 상태가 남아 끊김/실패 배너가 오표시되거나 입력창이
       // 잘못 활성화되지 않도록, 초기 connect 전까지 연결 UI 상태를 초기화한다.
       setSocketConnected(false);
       setHasDisconnected(false);
+      setReconnectFailed(false);
       getRoomInfo();
       getMyInfo();
       getChatList();
@@ -341,6 +349,12 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
     setShowMyChatOptions(_ => true);
   }, []);
 
+  const connectionBannerMessage = reconnectFailed
+    ? '채팅 연결에 실패했습니다. 채팅방에 다시 입장해 주세요'
+    : !socketConnected && hasDisconnected
+    ? '연결이 끊어졌습니다. 재연결 중…'
+    : null;
+
   return (
     <SafeAreaView
       style={{backgroundColor: backgroundColor(isDarkMode), flex: 1}}>
@@ -381,7 +395,7 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
         </TouchableOpacity>
       </View>
 
-      {!socketConnected && hasDisconnected && (
+      {connectionBannerMessage && (
         <View style={styles.socketConnection}>
           <View
             style={[
@@ -394,7 +408,7 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
               color={isDarkMode ? '#FFFFFF' : '#000000'}
             />
             <Text style={{color: textColor(isDarkMode)}}>
-              연결이 끊어졌습니다. 재연결 중…
+              {connectionBannerMessage}
             </Text>
           </View>
         </View>

--- a/src/screens/paxi/NewChatScreen.tsx
+++ b/src/screens/paxi/NewChatScreen.tsx
@@ -29,6 +29,11 @@ import paxi_api from '@utils/paxi_api';
 import {textColor, borderColor, backgroundColor, common} from '@styles/default';
 import {socketFactory} from '@utils/socket-factory';
 import {refreshAccessToken} from '@utils/refresh.utils';
+import {
+  createReauthGuard,
+  reconnectWithFreshToken,
+  ReauthGuard,
+} from '@utils/socket-reauth';
 import ChatMessage from '@components/chat/ChatMessage';
 import SidebarModal from '@components/chat/SidebarModal';
 import SettlementInfoBox from '@components/chat/SettlementInfoBox';
@@ -54,9 +59,8 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
   const [chatList, setChatList] = useState<MessageData[]>([]);
   const [newChat, setNewChat] = useState<string>('');
   const socketRef = useRef<Socket | null>(null);
-  // 토큰 만료 → 갱신 → 재연결 사이클의 중복 진입/무한 루프 방지용
-  const isReauthingRef = useRef<boolean>(false);
-  const reauthCountRef = useRef<number>(0);
+  // 토큰 만료 → 갱신 → 재연결 사이클의 중복 진입/무한 루프 방지용 가드
+  const reauthGuardRef = useRef<ReauthGuard>(createReauthGuard());
   const [reconnectAttempt, setReconnectAttempt] = useState<number>(0);
   const [socketConnected, setSocketConnected] = useState<boolean>(false);
 
@@ -151,7 +155,7 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
   const onSocketConnected = async () => {
     setSocketConnected(true);
     setReconnectAttempt(0);
-    reauthCountRef.current = 0; // 정상 연결되면 토큰 갱신 카운터 초기화
+    reauthGuardRef.current.reauthCount = 0; // 정상 연결되면 토큰 갱신 카운터 초기화
     paxi_api.post(`/room/join/${roomUuid}`);
   };
 
@@ -163,34 +167,14 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
   // 웹소켓 연결 시 액세스 토큰이 만료된 경우: 리프레시 토큰으로 갱신한 뒤
   // 새 토큰으로 소켓을 재생성한다. 서버가 client.disconnect()로 끊으므로
   // socket.io 자동 재연결은 일어나지 않고, 이 핸들러가 유일한 복구 경로다.
-  const onAccessTokenExpired = async () => {
-    if (isReauthingRef.current) {
-      return; // 이벤트 중복 수신 시 1회만 갱신
-    }
-    isReauthingRef.current = true;
-
-    // 갱신 직후 다시 만료가 반복되면(서버 시계 오차 등) 무한 루프를 끊는다.
-    if (reauthCountRef.current >= 2) {
-      console.error('토큰 갱신 반복 실패 — 재연결 중단');
-      releaseCurrentSocket();
-      isReauthingRef.current = false;
-      return;
-    }
-    reauthCountRef.current += 1;
-
-    try {
-      setSocketConnected(false);
-      releaseCurrentSocket(); // stale 토큰 소켓 정리
-      await refreshAccessToken(); // 새 access/refresh 토큰 발급 + 저장
-      await initSocket(); // 새 토큰으로 소켓 재생성
-    } catch (err) {
-      // refreshAccessToken 내부에서 reset_auth + 로그인 화면 이동까지 처리됨
-      console.error('토큰 갱신 실패, 재연결 중단:', err);
-      releaseCurrentSocket();
-    } finally {
-      isReauthingRef.current = false;
-    }
-  };
+  // 오케스트레이션 로직은 socket-reauth로 분리해 단위 테스트한다.
+  const onAccessTokenExpired = () =>
+    reconnectWithFreshToken(reauthGuardRef.current, {
+      releaseSocket: releaseCurrentSocket,
+      refreshAccessToken,
+      recreateSocket: initSocket,
+      setSocketConnected,
+    });
 
   const initSocket = async () => {
     console.debug('새 웹소켓 생성 중...');

--- a/src/screens/paxi/NewChatScreen.tsx
+++ b/src/screens/paxi/NewChatScreen.tsx
@@ -61,6 +61,8 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
   const socketRef = useRef<Socket | null>(null);
   // 토큰 만료 → 갱신 → 재연결 사이클의 중복 진입/무한 루프 방지용 가드
   const reauthGuardRef = useRef<ReauthGuard>(createReauthGuard());
+  // 최초 연결과 재연결을 구분 (최초 연결은 useFocusEffect 초기 조회와 중복되므로 재조회 생략)
+  const hasConnectedOnceRef = useRef<boolean>(false);
   const [reconnectAttempt, setReconnectAttempt] = useState<number>(0);
   const [socketConnected, setSocketConnected] = useState<boolean>(false);
 
@@ -156,6 +158,17 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
     setSocketConnected(true);
     setReconnectAttempt(0);
     reauthGuardRef.current.reauthCount = 0; // 정상 연결되면 토큰 갱신 카운터 초기화
+
+    // 재연결 시 끊긴 동안 놓친 데이터를 재조회한다. 최초 연결은
+    // useFocusEffect의 초기 조회와 중복되므로 건너뛴다.
+    if (hasConnectedOnceRef.current) {
+      getRoomInfo();
+      getSettlementInfo();
+      getMyInfo();
+      getChatList();
+    }
+    hasConnectedOnceRef.current = true;
+
     paxi_api.post(`/room/join/${roomUuid}`);
   };
 
@@ -246,15 +259,6 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
   };
 
   useEffect(() => {
-    if (socketRef.current?.connected) {
-      getRoomInfo();
-      getSettlementInfo();
-      getMyInfo();
-      getChatList();
-    }
-  }, [reconnectAttempt]);
-
-  useEffect(() => {
     if (!myInfo?.uuid || !Array.isArray(roomInfo?.roomUsers)) {
       return;
     }
@@ -269,6 +273,8 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
 
   useFocusEffect(
     useCallback(() => {
+      // 포커스마다 새 소켓을 생성하므로 첫 connect를 최초 연결로 취급한다.
+      hasConnectedOnceRef.current = false;
       getRoomInfo();
       getMyInfo();
       getChatList();

--- a/src/screens/paxi/NewChatScreen.tsx
+++ b/src/screens/paxi/NewChatScreen.tsx
@@ -275,6 +275,10 @@ const NewChatScreen: React.FC<NewChatScreenProps> = ({navigation}) => {
     useCallback(() => {
       // 포커스마다 새 소켓을 생성하므로 첫 connect를 최초 연결로 취급한다.
       hasConnectedOnceRef.current = false;
+      // 이전 세션의 연결 상태가 남아 끊김 배너가 오표시되거나 입력창이
+      // 잘못 활성화되지 않도록, 초기 connect 전까지 연결 UI 상태를 초기화한다.
+      setSocketConnected(false);
+      setHasDisconnected(false);
       getRoomInfo();
       getMyInfo();
       getChatList();

--- a/src/screens/paxi/NewChatScreen.tsx
+++ b/src/screens/paxi/NewChatScreen.tsx
@@ -542,13 +542,11 @@ const styles = StyleSheet.create({
     borderRadius: 20,
   },
   socketConnection: {
+    // 헤더 바로 아래 레이아웃 흐름에 배치 (절대 위치 top 하드코딩 시
+    // 헤더 높이/노치 환경에서 어긋나던 문제 해소)
     paddingHorizontal: 10,
     marginTop: 10,
-    position: 'absolute',
-    zIndex: 1000,
-    width: '100%',
     height: 50,
-    top: 60,
   },
   socketConnectionInner: {
     borderRadius: 5,

--- a/src/utils/__tests__/socket-factory.test.ts
+++ b/src/utils/__tests__/socket-factory.test.ts
@@ -38,7 +38,12 @@ const setup = async () => {
     onSocketDisconnected,
     onAccessTokenExpired,
   )) as FakeSocket;
-  return {socket, onSocketConnected, onSocketDisconnected, onAccessTokenExpired};
+  return {
+    socket,
+    onSocketConnected,
+    onSocketDisconnected,
+    onAccessTokenExpired,
+  };
 };
 
 beforeEach(async () => {
@@ -100,8 +105,12 @@ describe('socketFactory', () => {
   });
 
   it('accessTokenExpired는 일반 연결/해제 콜백을 호출하지 않는다', async () => {
-    const {socket, onSocketConnected, onSocketDisconnected, onAccessTokenExpired} =
-      await setup();
+    const {
+      socket,
+      onSocketConnected,
+      onSocketDisconnected,
+      onAccessTokenExpired,
+    } = await setup();
 
     socket.trigger(ChatEvent.ACCESS_TOKEN_EXPIRED);
 

--- a/src/utils/__tests__/socket-factory.test.ts
+++ b/src/utils/__tests__/socket-factory.test.ts
@@ -72,12 +72,20 @@ describe('socketFactory', () => {
     );
   });
 
-  it('connect 이벤트에서 onSocketConnected를 호출한다', async () => {
+  it('connected 이벤트에서 onSocketConnected를 호출한다', async () => {
+    const {socket, onSocketConnected} = await setup();
+
+    socket.trigger(ChatEvent.CONNECTED);
+
+    expect(onSocketConnected).toHaveBeenCalledTimes(1);
+  });
+
+  it('전송 connect 이벤트로는 onSocketConnected를 호출하지 않는다', async () => {
     const {socket, onSocketConnected} = await setup();
 
     socket.trigger('connect');
 
-    expect(onSocketConnected).toHaveBeenCalledTimes(1);
+    expect(onSocketConnected).not.toHaveBeenCalled();
   });
 
   it('disconnect 이벤트에서 onSocketDisconnected를 호출한다', async () => {

--- a/src/utils/__tests__/socket-factory.test.ts
+++ b/src/utils/__tests__/socket-factory.test.ts
@@ -1,0 +1,112 @@
+import EncryptedStorage from 'react-native-encrypted-storage';
+import {io} from 'socket.io-client';
+import {socketFactory} from '../socket-factory';
+import {PAXI_API_URL} from '../paxi_api';
+import {AUTH_TOKEN_KEY} from '../storage-keys';
+import {ChatEvent} from '../../constants/socket-events';
+
+// socket.io-client mock — io() 호출마다 핸들러를 기록하는 가짜 소켓을 만든다.
+// 반환된 소켓의 trigger()로 서버 이벤트 수신을 시뮬레이션한다.
+jest.mock('socket.io-client', () => {
+  const makeSocket = () => {
+    const handlers: Record<string, (...args: any[]) => void> = {};
+    return {
+      on: jest.fn((event: string, cb: (...args: any[]) => void) => {
+        handlers[event] = cb;
+      }),
+      emit: jest.fn(),
+      disconnect: jest.fn(),
+      // 테스트 헬퍼: 등록된 핸들러를 강제로 호출
+      trigger: (event: string, ...args: any[]) => handlers[event]?.(...args),
+    };
+  };
+  return {io: jest.fn(() => makeSocket())};
+});
+
+const mockIo = io as jest.Mock;
+
+type FakeSocket = Awaited<ReturnType<typeof socketFactory>> & {
+  trigger: (event: string, ...args: any[]) => void;
+};
+
+const setup = async () => {
+  const onSocketConnected = jest.fn();
+  const onSocketDisconnected = jest.fn();
+  const onAccessTokenExpired = jest.fn();
+  const socket = (await socketFactory(
+    onSocketConnected,
+    onSocketDisconnected,
+    onAccessTokenExpired,
+  )) as FakeSocket;
+  return {socket, onSocketConnected, onSocketDisconnected, onAccessTokenExpired};
+};
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  await EncryptedStorage.clear();
+});
+
+describe('socketFactory', () => {
+  it('EncryptedStorage의 토큰을 URL 쿼리와 auth에 담아 연결한다', async () => {
+    await EncryptedStorage.setItem(AUTH_TOKEN_KEY, 'my-token');
+
+    await setup();
+
+    expect(mockIo).toHaveBeenCalledWith(
+      `${PAXI_API_URL}?Authentication=my-token`,
+      expect.objectContaining({auth: {token: 'my-token'}}),
+    );
+  });
+
+  it('토큰이 없으면 빈 문자열로 연결한다', async () => {
+    await setup();
+
+    expect(mockIo).toHaveBeenCalledWith(
+      `${PAXI_API_URL}?Authentication=`,
+      expect.objectContaining({auth: {token: ''}}),
+    );
+  });
+
+  it('connect 이벤트에서 onSocketConnected를 호출한다', async () => {
+    const {socket, onSocketConnected} = await setup();
+
+    socket.trigger('connect');
+
+    expect(onSocketConnected).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnect 이벤트에서 onSocketDisconnected를 호출한다', async () => {
+    const {socket, onSocketDisconnected} = await setup();
+
+    socket.trigger('disconnect', 'transport close');
+
+    expect(onSocketDisconnected).toHaveBeenCalledTimes(1);
+  });
+
+  it('error 이벤트에서 onSocketDisconnected를 호출한다', async () => {
+    const {socket, onSocketDisconnected} = await setup();
+
+    socket.trigger(ChatEvent.ERROR, {message: 'boom', stack: 'stack'});
+
+    expect(onSocketDisconnected).toHaveBeenCalledTimes(1);
+  });
+
+  it('accessTokenExpired 이벤트에서 onAccessTokenExpired를 호출한다', async () => {
+    const {socket, onAccessTokenExpired} = await setup();
+
+    socket.trigger(ChatEvent.ACCESS_TOKEN_EXPIRED);
+
+    expect(onAccessTokenExpired).toHaveBeenCalledTimes(1);
+  });
+
+  it('accessTokenExpired는 일반 연결/해제 콜백을 호출하지 않는다', async () => {
+    const {socket, onSocketConnected, onSocketDisconnected, onAccessTokenExpired} =
+      await setup();
+
+    socket.trigger(ChatEvent.ACCESS_TOKEN_EXPIRED);
+
+    expect(onAccessTokenExpired).toHaveBeenCalledTimes(1);
+    expect(onSocketConnected).not.toHaveBeenCalled();
+    expect(onSocketDisconnected).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/socket-reauth.test.ts
+++ b/src/utils/__tests__/socket-reauth.test.ts
@@ -9,6 +9,7 @@ const makeDeps = (overrides: Partial<ReauthDeps> = {}) => ({
   refreshAccessToken: jest.fn().mockResolvedValue(undefined),
   recreateSocket: jest.fn().mockResolvedValue(undefined),
   setSocketConnected: jest.fn(),
+  onGiveUp: jest.fn(),
   ...overrides,
 });
 
@@ -101,6 +102,27 @@ describe('reconnectWithFreshToken', () => {
     expect(deps.recreateSocket).not.toHaveBeenCalled();
     expect(deps.setSocketConnected).toHaveBeenCalledWith(false);
     expect(deps.releaseSocket).toHaveBeenCalledTimes(1);
+  });
+
+  it('상한 도달로 중단할 때 onGiveUp을 호출한다', async () => {
+    const deps = makeDeps();
+    const guard = createReauthGuard();
+    guard.reauthCount = 2; // 이미 상한 도달 상태
+
+    await reconnectWithFreshToken(guard, {...deps, maxAttempts: 2});
+
+    expect(deps.onGiveUp).toHaveBeenCalledTimes(1);
+    expect(deps.recreateSocket).not.toHaveBeenCalled();
+  });
+
+  it('정상 재연결 경로에서는 onGiveUp을 호출하지 않는다', async () => {
+    const deps = makeDeps();
+    const guard = createReauthGuard();
+
+    await reconnectWithFreshToken(guard, deps);
+
+    expect(deps.onGiveUp).not.toHaveBeenCalled();
+    expect(deps.recreateSocket).toHaveBeenCalledTimes(1);
   });
 
   it('정상 연결로 카운트가 초기화되면 다시 갱신을 시도한다', async () => {

--- a/src/utils/__tests__/socket-reauth.test.ts
+++ b/src/utils/__tests__/socket-reauth.test.ts
@@ -115,7 +115,9 @@ describe('reconnectWithFreshToken', () => {
 
   it('토큰 갱신 실패 시 소켓만 정리하고 재생성하지 않는다', async () => {
     const deps = makeDeps({
-      refreshAccessToken: jest.fn().mockRejectedValue(new Error('refresh 실패')),
+      refreshAccessToken: jest
+        .fn()
+        .mockRejectedValue(new Error('refresh 실패')),
     });
     const guard = createReauthGuard();
 

--- a/src/utils/__tests__/socket-reauth.test.ts
+++ b/src/utils/__tests__/socket-reauth.test.ts
@@ -90,6 +90,19 @@ describe('reconnectWithFreshToken', () => {
     expect(guard.isReauthing).toBe(false);
   });
 
+  it('상한 도달로 중단할 때도 연결 상태를 false로 갱신한다', async () => {
+    const deps = makeDeps();
+    const guard = createReauthGuard();
+    guard.reauthCount = 2; // 이미 상한 도달 상태
+
+    await reconnectWithFreshToken(guard, {...deps, maxAttempts: 2});
+
+    // 재생성은 하지 않지만 UI가 연결됨으로 남지 않도록 끊김 처리는 한다
+    expect(deps.recreateSocket).not.toHaveBeenCalled();
+    expect(deps.setSocketConnected).toHaveBeenCalledWith(false);
+    expect(deps.releaseSocket).toHaveBeenCalledTimes(1);
+  });
+
   it('정상 연결로 카운트가 초기화되면 다시 갱신을 시도한다', async () => {
     const deps = makeDeps();
     const guard = createReauthGuard();

--- a/src/utils/__tests__/socket-reauth.test.ts
+++ b/src/utils/__tests__/socket-reauth.test.ts
@@ -1,0 +1,140 @@
+import {
+  createReauthGuard,
+  reconnectWithFreshToken,
+  ReauthDeps,
+} from '../socket-reauth';
+
+const makeDeps = (overrides: Partial<ReauthDeps> = {}) => ({
+  releaseSocket: jest.fn(),
+  refreshAccessToken: jest.fn().mockResolvedValue(undefined),
+  recreateSocket: jest.fn().mockResolvedValue(undefined),
+  setSocketConnected: jest.fn(),
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  (console.error as jest.Mock).mockRestore();
+});
+
+describe('createReauthGuard', () => {
+  it('초기 상태는 비활성 + 카운트 0이다', () => {
+    expect(createReauthGuard()).toEqual({isReauthing: false, reauthCount: 0});
+  });
+});
+
+describe('reconnectWithFreshToken', () => {
+  it('정리 → 토큰 갱신 → 소켓 재생성 순서로 실행한다', async () => {
+    const order: string[] = [];
+    const deps = makeDeps({
+      releaseSocket: jest.fn(() => order.push('release')),
+      refreshAccessToken: jest.fn(async () => {
+        order.push('refresh');
+      }),
+      recreateSocket: jest.fn(async () => {
+        order.push('recreate');
+      }),
+    });
+    const guard = createReauthGuard();
+
+    await reconnectWithFreshToken(guard, deps);
+
+    expect(order).toEqual(['release', 'refresh', 'recreate']);
+    expect(deps.setSocketConnected).toHaveBeenCalledWith(false);
+    expect(guard.reauthCount).toBe(1);
+    expect(guard.isReauthing).toBe(false); // 종료 후 가드 해제
+  });
+
+  it('진행 중이면 중복 호출을 무시한다 (이벤트 중복 수신 방어)', async () => {
+    let resolveRefresh: () => void = () => {};
+    const deps = makeDeps({
+      refreshAccessToken: jest.fn(
+        () =>
+          new Promise<void>(resolve => {
+            resolveRefresh = resolve;
+          }),
+      ),
+    });
+    const guard = createReauthGuard();
+
+    const first = reconnectWithFreshToken(guard, deps); // 갱신 대기 중
+    const second = reconnectWithFreshToken(guard, deps); // 무시되어야 함
+    await second;
+
+    expect(deps.refreshAccessToken).toHaveBeenCalledTimes(1);
+    expect(deps.recreateSocket).not.toHaveBeenCalled();
+
+    resolveRefresh();
+    await first;
+
+    expect(deps.recreateSocket).toHaveBeenCalledTimes(1);
+    expect(guard.reauthCount).toBe(1);
+  });
+
+  it('정상 연결 없이 maxAttempts에 도달하면 재연결을 중단한다', async () => {
+    const deps = makeDeps();
+    const guard = createReauthGuard();
+
+    // 연속 3회 — 1,2회는 시도, 3회째는 카운트 상한으로 중단
+    await reconnectWithFreshToken(guard, deps);
+    await reconnectWithFreshToken(guard, deps);
+    await reconnectWithFreshToken(guard, deps);
+
+    expect(deps.refreshAccessToken).toHaveBeenCalledTimes(2);
+    expect(deps.recreateSocket).toHaveBeenCalledTimes(2);
+    expect(guard.reauthCount).toBe(2);
+    expect(guard.isReauthing).toBe(false);
+  });
+
+  it('정상 연결로 카운트가 초기화되면 다시 갱신을 시도한다', async () => {
+    const deps = makeDeps();
+    const guard = createReauthGuard();
+
+    await reconnectWithFreshToken(guard, deps);
+    await reconnectWithFreshToken(guard, deps);
+    guard.reauthCount = 0; // 정상 연결 시 호출 측에서 초기화하는 동작 모사
+
+    await reconnectWithFreshToken(guard, deps);
+
+    expect(deps.refreshAccessToken).toHaveBeenCalledTimes(3);
+  });
+
+  it('maxAttempts는 인자로 조정할 수 있다', async () => {
+    const deps = makeDeps();
+    const guard = createReauthGuard();
+
+    await reconnectWithFreshToken(guard, {...deps, maxAttempts: 1});
+    await reconnectWithFreshToken(guard, {...deps, maxAttempts: 1});
+
+    expect(deps.refreshAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('토큰 갱신 실패 시 소켓만 정리하고 재생성하지 않는다', async () => {
+    const deps = makeDeps({
+      refreshAccessToken: jest.fn().mockRejectedValue(new Error('refresh 실패')),
+    });
+    const guard = createReauthGuard();
+
+    await reconnectWithFreshToken(guard, deps);
+
+    expect(deps.recreateSocket).not.toHaveBeenCalled();
+    expect(deps.releaseSocket).toHaveBeenCalledTimes(2); // 갱신 전 + 실패 후
+    expect(guard.isReauthing).toBe(false); // 실패해도 가드 해제
+  });
+
+  it('소켓 재생성 실패 시에도 가드를 해제한다', async () => {
+    const deps = makeDeps({
+      recreateSocket: jest.fn().mockRejectedValue(new Error('recreate 실패')),
+    });
+    const guard = createReauthGuard();
+
+    await reconnectWithFreshToken(guard, deps);
+
+    expect(guard.isReauthing).toBe(false);
+    expect(deps.releaseSocket).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/socket-factory.ts
+++ b/src/utils/socket-factory.ts
@@ -30,7 +30,13 @@ export const socketFactory = async (
   console.debug('웹소켓 연결 중...');
 
   socket.on('connect', () => {
-    console.debug('웹소켓 연결 완료');
+    // 전송 계층 연결일 뿐 인증 확정이 아니다. 서버가 handleConnection에서 토큰을
+    // 검증한 뒤 connected 이벤트를 보내야 실제 사용 가능 상태다.
+    console.debug('웹소켓 전송 계층 연결 (인증 확정 전)');
+  });
+
+  socket.on(ChatEvent.CONNECTED, () => {
+    console.debug('웹소켓 서버 인증 완료');
     onSocketConnected();
   });
 

--- a/src/utils/socket-factory.ts
+++ b/src/utils/socket-factory.ts
@@ -18,6 +18,9 @@ export const socketFactory = async (
     forceNew: true,
     reconnection: true,
     reconnectionDelay: 5000,
+    // 점증 백오프: 5s에서 시작해 시도마다 늘어나 최대 30s에서 캡.
+    // 고정 5s 재시도는 장애 시 서버에 불필요한 부하를 준다.
+    reconnectionDelayMax: 30000,
     reconnectionAttempts: Infinity,
     auth: {
       token: token,

--- a/src/utils/socket-factory.ts
+++ b/src/utils/socket-factory.ts
@@ -7,6 +7,13 @@ import {ChatEvent} from '../constants/socket-events';
 
 const SOCKET_URL = PAXI_API_URL;
 
+interface WsErrorPayload {
+  status: 'error';
+  message: string;
+  timestamp: string;
+  error?: string;
+}
+
 export const socketFactory = async (
   onSocketConnected: () => void,
   onSocketDisconnected: () => void,
@@ -48,9 +55,8 @@ export const socketFactory = async (
     onAccessTokenExpired();
   });
 
-  socket.on(ChatEvent.ERROR, error => {
-    console.error('웹소켓 에러 발생:', error.message);
-    console.error(error.stack);
+  socket.on(ChatEvent.ERROR, (error: WsErrorPayload) => {
+    console.error('웹소켓 에러 발생:', error?.error, error?.message);
     onSocketDisconnected();
   });
 

--- a/src/utils/socket-factory.ts
+++ b/src/utils/socket-factory.ts
@@ -10,6 +10,7 @@ const SOCKET_URL = PAXI_API_URL;
 export const socketFactory = async (
   onSocketConnected: () => void,
   onSocketDisconnected: () => void,
+  onAccessTokenExpired: () => void,
 ): Promise<Socket> => {
   const token = (await EncryptedStorage.getItem(AUTH_TOKEN_KEY)) ?? '';
   const socket = io(`${SOCKET_URL}?Authentication=${token}`, {
@@ -31,8 +32,11 @@ export const socketFactory = async (
   });
 
   socket.on(ChatEvent.ACCESS_TOKEN_EXPIRED, () => {
-    console.error('액세스 토큰 만료');
-    // TODO: 리프레시 토큰 이용해 갱신 후 웹소켓 재연결
+    console.error('액세스 토큰 만료 — 갱신 후 웹소켓 재연결 시도');
+    // 토큰이 URL 쿼리에 박혀 생성 시점에만 읽히므로, 자동 재연결로는
+    // 만료된 토큰이 그대로 재사용된다. 소켓 소유자가 토큰을 갱신하고
+    // 소켓을 재생성하도록 위임한다.
+    onAccessTokenExpired();
   });
 
   socket.on(ChatEvent.ERROR, error => {

--- a/src/utils/socket-reauth.ts
+++ b/src/utils/socket-reauth.ts
@@ -1,0 +1,71 @@
+// 웹소켓 연결 시 액세스 토큰이 만료된 경우의 재인증·재연결 오케스트레이션.
+// NewChatScreen에서 분리해 단위 테스트가 가능하도록 의존성을 주입받는다.
+
+// 중복 진입/무한 루프를 막기 위한 가변 상태. 컴포넌트에서는 useRef로 보관한다.
+export type ReauthGuard = {
+  // 갱신·재연결 사이클이 진행 중인지 (이벤트 중복 수신 방어)
+  isReauthing: boolean;
+  // 정상 연결 없이 반복된 갱신 횟수 (서버 시계 오차 등으로 인한 무한 루프 방어)
+  reauthCount: number;
+};
+
+export type ReauthDeps = {
+  // stale 토큰 소켓 정리
+  releaseSocket: () => void;
+  // 리프레시 토큰으로 새 access/refresh 토큰 발급 + 저장
+  refreshAccessToken: () => Promise<unknown>;
+  // 새 토큰으로 소켓 재생성
+  recreateSocket: () => Promise<void>;
+  // 재연결 진행 동안 연결 상태 표시 갱신 (선택)
+  setSocketConnected?: (connected: boolean) => void;
+  // 정상 연결 없이 허용할 최대 갱신 횟수 (기본 2)
+  maxAttempts?: number;
+};
+
+export const createReauthGuard = (): ReauthGuard => ({
+  isReauthing: false,
+  reauthCount: 0,
+});
+
+/**
+ * 토큰 만료 이벤트를 받았을 때 갱신 후 소켓을 재생성한다.
+ *
+ * - 진행 중이면(`isReauthing`) 즉시 반환해 중복 갱신을 막는다.
+ * - 정상 연결 없이 `maxAttempts`회 이상 반복되면 재연결을 중단한다.
+ * - 갱신 실패 시 소켓만 정리한다. (refreshAccessToken 내부에서 로그아웃 처리)
+ *
+ * `reauthCount`는 정상 연결 시 호출 측에서 0으로 초기화한다.
+ */
+export const reconnectWithFreshToken = async (
+  guard: ReauthGuard,
+  deps: ReauthDeps,
+): Promise<void> => {
+  const maxAttempts = deps.maxAttempts ?? 2;
+
+  if (guard.isReauthing) {
+    return; // 이벤트 중복 수신 시 1회만 갱신
+  }
+  guard.isReauthing = true;
+
+  try {
+    if (guard.reauthCount >= maxAttempts) {
+      console.error('토큰 갱신 반복 실패 — 재연결 중단');
+      deps.releaseSocket();
+      return;
+    }
+    guard.reauthCount += 1;
+
+    try {
+      deps.setSocketConnected?.(false);
+      deps.releaseSocket(); // stale 토큰 소켓 정리
+      await deps.refreshAccessToken(); // 새 access/refresh 토큰 발급 + 저장
+      await deps.recreateSocket(); // 새 토큰으로 소켓 재생성
+    } catch (err) {
+      // refreshAccessToken 내부에서 reset_auth + 로그인 화면 이동까지 처리됨
+      console.error('토큰 갱신 실패, 재연결 중단:', err);
+      deps.releaseSocket();
+    }
+  } finally {
+    guard.isReauthing = false;
+  }
+};

--- a/src/utils/socket-reauth.ts
+++ b/src/utils/socket-reauth.ts
@@ -18,6 +18,8 @@ export type ReauthDeps = {
   recreateSocket: () => Promise<void>;
   // 재연결 진행 동안 연결 상태 표시 갱신 (선택)
   setSocketConnected?: (connected: boolean) => void;
+  // 재연결을 포기했을 때(상한 도달) 호출. UI에 종료 상태를 알린다. (선택)
+  onGiveUp?: () => void;
   // 정상 연결 없이 허용할 최대 갱신 횟수 (기본 2)
   maxAttempts?: number;
 };
@@ -51,9 +53,11 @@ export const reconnectWithFreshToken = async (
     if (guard.reauthCount >= maxAttempts) {
       console.error('토큰 갱신 반복 실패 — 재연결 중단');
       // releaseSocket은 리스너 제거 후 disconnect하므로 disconnect 이벤트가
-      // 발생하지 않는다. UI가 연결됨으로 남지 않도록 명시적으로 끊김 처리한다.
+      // 발생하지 않는다. UI가 연결됨으로 남지 않도록 명시적으로 끊김 처리하고,
+      // onGiveUp으로 종료 상태를 알린다(재입장으로만 복구).
       deps.setSocketConnected?.(false);
       deps.releaseSocket();
+      deps.onGiveUp?.();
       return;
     }
     guard.reauthCount += 1;

--- a/src/utils/socket-reauth.ts
+++ b/src/utils/socket-reauth.ts
@@ -50,6 +50,9 @@ export const reconnectWithFreshToken = async (
   try {
     if (guard.reauthCount >= maxAttempts) {
       console.error('토큰 갱신 반복 실패 — 재연결 중단');
+      // releaseSocket은 리스너 제거 후 disconnect하므로 disconnect 이벤트가
+      // 발생하지 않는다. UI가 연결됨으로 남지 않도록 명시적으로 끊김 처리한다.
+      deps.setSocketConnected?.(false);
       deps.releaseSocket();
       return;
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

X (서버: PoApper/paxi-popo-nest-api#154 와 세트로 동작)

## 📝 작업 내용

Paxi 채팅방(`NewChatScreen`) 소켓 연결의 토큰 만료 복구와 끊김 안내를 개선합니다.
`src/screens/paxi/HANDOFF.md` "채팅 소켓 재연결 안내 개선" 섹션의 #1~#5 중 보안(토큰 query string 제거)을 제외한 전부를 처리했습니다.

### 기존

- **토큰 만료 시 복구 불가**: 토큰이 소켓 생성 시 URL/`auth`에 박혀, 자동 재연결이 만료된 토큰을 그대로 재사용 → 5초마다 영원히 실패. `accessTokenExpired` 핸들러는 TODO만 있고 미구현.
- **부정확한 안내**: "재연결 시도 N회"의 N은 `disconnect`/`error` 양쪽에서 증가하는 끊김 누적 수일 뿐 실제 재연결 시도 횟수가 아니며, 숫자가 커질수록 불안만 유발.
- **취약한 재조회**: 놓친 메시지 재조회가 `useEffect([reconnectAttempt])`의 "0으로 리셋되는 부수효과"에 의존하는 비직관적 구조.
- 고정 5초 재시도(백오프 없음), 끊김 배너 위치 `top: 60` 하드코딩.

### 작업 후

- **토큰 만료 → 갱신 → 소켓 재생성**: `accessTokenExpired` 수신 시 `refreshAccessToken()`으로 토큰을 갱신하고 새 토큰으로 소켓을 재생성. 오케스트레이션은 `socket-reauth.ts`(`reconnectWithFreshToken`)로 분리하고 중복 진입/반복 실패(최대 2회) 가드 추가. 갱신 실패 시 기존 로그아웃 흐름에 위임.
- **안내 단순화**: `reconnectAttempt`(number) → `hasDisconnected`(boolean), 문구 "연결이 끊어졌습니다. 재연결 중…"으로 변경(이중 카운팅 문제 제거).
- **재조회 명시화**: 재연결 성공 콜백 `onSocketConnected`에서 직접 재조회. `hasConnectedOnceRef`로 최초 연결의 중복 조회 방지.
- **점증 백오프**: `reconnectionDelayMax`(30s) 추가. **배너 레이아웃**: 절대 위치 → 헤더 아래 레이아웃 흐름 배치.

## ✅ 테스트 여부 체크(환경 명시) & 스크린샷

- [ ] Android 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) API 36, Android 14
- [ ] iOS 환경에서 기능이 의도대로 작동함을 확인했습니다. 환경) iOS 18.5

> 단위 테스트: `socket-factory.test.ts`(이벤트 배선/위임 7건), `socket-reauth.test.ts`(순서·중복무시·상한·실패 시 가드해제 8건) 추가. 전체 `jest` 34/34 통과, `npm run pc` 통과.
> **실기기 시나리오 미검증** — 짧은 만료 토큰으로 (1)끊김→재연결 (2)토큰 만료→갱신 (3)갱신 실패→로그인 이동 3가지를 서버 협조 하에 확인 필요.

## 💬 리뷰 요구사항 (선택)

- 이 PR은 서버 PR(paxi-popo-nest-api#154, `accessTokenExpired` 이벤트 emit)과 **세트로 머지**되어야 실효성이 있습니다. 서버 측 머지 일정과 맞춰주세요.
- HANDOFF #5 보안 항목(토큰 query string 제거)은 서버 핸드셰이크가 `auth.token`만으로 인증을 수용하는지 확인이 필요해 이번 범위에서 제외했습니다.